### PR TITLE
feat: 统一探索发现页 /discovery（插画·漫画 / 小说 / 推荐用户）

### DIFF
--- a/app/api/discovery-users.ts
+++ b/app/api/discovery-users.ts
@@ -1,0 +1,56 @@
+import type { ArtworkInfo, NovelInfo, UserListItem } from '~/types'
+
+export interface DiscoveryUsersBody {
+  recommendedUsers: {
+    userId: string
+    recentIllustIds: string[]
+    recentNovelIds: string[]
+  }[]
+  users: {
+    userId: `${number}`
+    name: string
+    image: string
+    comment: string
+    isFollowed: boolean
+    followedBack: boolean
+    isMypixiv: boolean
+    isBlocking: boolean
+    commission?: { acceptRequest: boolean } | null
+  }[]
+  thumbnails: {
+    illust?: ArtworkInfo[]
+    novel?: NovelInfo[]
+  }
+}
+
+// Join the relational discovery/users payload into the denormalized
+// UserListItem shape consumed by FollowUserCard.
+export function buildDiscoveryUsers(body: DiscoveryUsersBody): UserListItem[] {
+  const userMap = new Map(body.users.map((u) => [u.userId, u]))
+  const illustMap = new Map((body.thumbnails.illust ?? []).map((i) => [i.id, i]))
+  const novelMap = new Map((body.thumbnails.novel ?? []).map((n) => [n.id, n]))
+
+  const result: UserListItem[] = []
+  for (const rec of body.recommendedUsers) {
+    const u = userMap.get(rec.userId as `${number}`)
+    if (!u) continue
+    result.push({
+      userId: u.userId,
+      userName: u.name,
+      profileImageUrl: u.image,
+      userComment: u.comment,
+      following: u.isFollowed,
+      followed: u.followedBack,
+      isBlocking: u.isBlocking,
+      isMypixiv: u.isMypixiv,
+      illusts: rec.recentIllustIds
+        .map((id) => illustMap.get(id as `${number}`))
+        .filter((x): x is ArtworkInfo => !!x),
+      novels: rec.recentNovelIds
+        .map((id) => novelMap.get(id as `${number}`))
+        .filter((x): x is NovelInfo => !!x),
+      acceptRequest: u.commission?.acceptRequest ?? false,
+    })
+  }
+  return result
+}

--- a/app/api/pixiv-client.ts
+++ b/app/api/pixiv-client.ts
@@ -2,6 +2,7 @@ import axios, { type AxiosInstance } from 'axios'
 import nprogress from 'nprogress'
 import { getToken, getCsrfToken } from '~/composables/userData'
 import { createPximgReplacer } from '~/utils/pximg'
+import { buildDiscoveryUsers, type DiscoveryUsersBody } from './discovery-users'
 import type {
   Artwork,
   ArtworkGallery,
@@ -318,6 +319,21 @@ export class PixivWebClient {
       { params: searchParams }
     )
     return this.unwrap(data)
+  }
+
+  async getDiscoveryUsers(params: {
+    limit?: number
+  }): Promise<UserListItem[]> {
+    const { data } = await this.http.get<PixivResponse<DiscoveryUsersBody>>(
+      '/ajax/discovery/users',
+      {
+        params: {
+          limit: String(params.limit ?? 20),
+          lang: 'zh',
+        },
+      }
+    )
+    return buildDiscoveryUsers(this.unwrap(data))
   }
 
   // ── Search ────────────────────────────────────────────────────────

--- a/app/components/SideNav/SideNav.vue
+++ b/app/components/SideNav/SideNav.vue
@@ -12,7 +12,7 @@ aside.global-side-nav(:class='{ hidden: !sideNavStore.isOpened }')
         ul
           SideNavListLink(link='/' text='首页')
             IFasHome.link-icon
-          SideNavListLink.not-allowed(link='' text='探索发现')
+          SideNavListLink(link='/discovery' text='探索发现')
             IFasImage.link-icon
           SideNavListLink(link='/ranking' text='排行榜')
             IFasCrown.link-icon

--- a/app/components/SideNav/SideNav.vue
+++ b/app/components/SideNav/SideNav.vue
@@ -12,10 +12,18 @@ aside.global-side-nav(:class='{ hidden: !sideNavStore.isOpened }')
         ul
           SideNavListLink(link='/' text='首页')
             IFasHome.link-icon
-          SideNavListLink(link='/discovery' text='探索发现')
-            IFasImage.link-icon
           SideNavListLink(link='/ranking' text='排行榜')
             IFasCrown.link-icon
+
+      .group
+        .title 探索发现
+        ul
+          SideNavListLink(link='/discovery/artworks' text='插画·漫画')
+            IFasImage.link-icon
+          SideNavListLink(link='/discovery/novels' text='小说')
+            IFasBook.link-icon
+          SideNavListLink(link='/discovery/users' text='用户')
+            IFasUser.link-icon
 
       .group
         .title 用户
@@ -55,6 +63,7 @@ import IFasExternalLinkAlt from '~icons/fa-solid/external-link-alt'
 import IFasFingerprint from '~icons/fa-solid/fingerprint'
 import IFasHeart from '~icons/fa-solid/heart'
 import IFasHome from '~icons/fa-solid/home'
+import IFasBook from '~icons/fa-solid/book'
 import IFasImage from '~icons/fa-solid/image'
 import IFasUser from '~icons/fa-solid/user'
 import { useSideNavStore, useUserStore } from '~/stores/session'

--- a/app/pages/discovery.vue
+++ b/app/pages/discovery.vue
@@ -84,6 +84,10 @@ onMounted(() => setTitle('探索发现'))
 </script>
 
 <style lang="scss" scoped>
+#discovery-view {
+  margin-top: 1.5rem;
+}
+
 .discover-header {
   display: flex;
   align-items: center;

--- a/app/pages/discovery.vue
+++ b/app/pages/discovery.vue
@@ -1,0 +1,137 @@
+<template lang="pug">
+#discovery-view.body-inner
+  .discover-header
+    h2
+      FnbIcon: ITablerCompass
+      |  探索发现
+    .discover-controls
+      .tab-nav
+        RouterLink.tab-item(
+          v-for='t in tabs',
+          :key='t.key',
+          :to='t.to',
+          :class='{ active: activeKey === t.key }'
+        ) {{ t.label }}
+      FnbSelect(
+        v-if='showModeSelect && userStore.isLoggedIn',
+        :model-value='discoveryMode',
+        :options='discoveryModeOptions',
+        @update:model-value='changeMode'
+      )
+      FnbButton(:loading='isLoading', @click='refresh', size='sm')
+        template(#icon): IFasRandom
+        | {{ isLoading ? '加载中' : '换一批' }}
+  NuxtPage
+</template>
+
+<script lang="ts" setup>
+import IFasRandom from '~icons/fa-solid/random'
+import { IconCompass as ITablerCompass } from '@tabler/icons-vue'
+import { useDiscoveryStore } from '~/stores/discovery'
+import { useUserStore } from '~/stores/session'
+import { setTitle } from '~/utils/setTitle'
+
+definePageMeta({ name: 'discovery' })
+
+const discoveryStore = useDiscoveryStore()
+const userStore = useUserStore()
+const route = useRoute()
+
+const discoveryModeOptions = [
+  { label: '混池', value: 'all' },
+  { label: '全年龄', value: 'safe' },
+  { label: 'R18', value: 'r18' },
+]
+
+const savedDiscoveryMode = useLocalStorage('pixivnow:discovery-mode', 'all')
+const discoveryMode = ref(savedDiscoveryMode.value)
+discoveryStore.discoveryMode = discoveryMode.value
+
+const tabs = [
+  { key: 'artworks', label: '插画·漫画', to: '/discovery/artworks' },
+  { key: 'novels', label: '小说', to: '/discovery/novels' },
+  { key: 'users', label: '用户', to: '/discovery/users' },
+]
+
+const activeKey = computed(() => {
+  if (route.path.startsWith('/discovery/novels')) return 'novels'
+  if (route.path.startsWith('/discovery/users')) return 'users'
+  return 'artworks'
+})
+
+const showModeSelect = computed(() => activeKey.value !== 'users')
+
+const isLoading = computed(() => {
+  if (activeKey.value === 'novels') return discoveryStore.loadingNovelDiscovery
+  if (activeKey.value === 'users') return discoveryStore.loadingUserDiscovery
+  return discoveryStore.loadingDiscovery
+})
+
+function refresh() {
+  if (activeKey.value === 'novels') discoveryStore.fetchNovelDiscovery()
+  else if (activeKey.value === 'users') discoveryStore.fetchUserDiscovery()
+  else discoveryStore.fetchDiscovery()
+}
+
+function changeMode(mode: string) {
+  discoveryMode.value = mode
+  savedDiscoveryMode.value = mode
+  discoveryStore.discoveryMode = mode
+  refresh()
+}
+
+onMounted(() => setTitle('探索发现'))
+</script>
+
+<style lang="scss" scoped>
+.discover-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-bottom: 1rem;
+
+  h2 {
+    font-family: var(--fnb-font-display);
+    font-weight: 900;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin: 0;
+  }
+}
+
+.discover-controls {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.tab-nav {
+  display: flex;
+  gap: 0.25rem;
+}
+
+.tab-item {
+  padding: 0.3rem 1rem;
+  border: 3px solid transparent;
+  border-radius: var(--fnb-radius-sm);
+  font-weight: 700;
+  color: var(--fnb-text-muted);
+  text-decoration: none;
+  transition: color 150ms, background 150ms;
+
+  &:hover {
+    color: var(--fnb-text);
+    background: color-mix(in srgb, var(--fnb-brand) 15%, var(--fnb-surface));
+  }
+
+  &.active {
+    color: #fff;
+    background: var(--fnb-brand);
+    border-color: var(--fnb-border);
+  }
+}
+</style>

--- a/app/pages/discovery/artworks.vue
+++ b/app/pages/discovery/artworks.vue
@@ -1,0 +1,66 @@
+<template lang="pug">
+#discovery-artworks
+  ArtworkList(
+    :list='discoveryStore.discoveryList',
+    :loading='discoveryStore.loadingDiscovery'
+  )
+  .discover-footer(v-if='!discoveryStore.loadingDiscovery')
+    .loading-more(v-if='userStore.isLoggedIn && discoveryStore.loadingMoreDiscovery')
+      FnbSkeleton(block, height='2rem', width='200px')
+    .login-prompt(v-else-if='!userStore.isLoggedIn && discoveryStore.discoveryList.length')
+      p 登录后解锁无限浏览
+      FnbButton(
+        size='sm',
+        variant='primary',
+        tag='RouterLink',
+        to='/login?back=/discovery/artworks'
+      )
+        template(#icon): ITablerLogin
+        | 登录
+    div(v-else-if='userStore.isLoggedIn', ref='scrollSentinel')
+</template>
+
+<script lang="ts" setup>
+import ArtworkList from '~/components/Artwork/ArtworkList.vue'
+import { IconLogin as ITablerLogin } from '@tabler/icons-vue'
+import { useDiscoveryStore } from '~/stores/discovery'
+import { useUserStore } from '~/stores/session'
+
+const discoveryStore = useDiscoveryStore()
+const userStore = useUserStore()
+const scrollSentinel = ref<HTMLElement | null>(null)
+
+useIntersectionObserver(scrollSentinel, ([{ isIntersecting }]) => {
+  if (isIntersecting && userStore.isLoggedIn) {
+    discoveryStore.appendDiscovery()
+  }
+})
+
+onMounted(() => {
+  if (!discoveryStore.discoveryList.length) {
+    discoveryStore.fetchDiscovery()
+  }
+})
+</script>
+
+<style lang="scss" scoped>
+.discover-footer {
+  margin-top: 2rem;
+  text-align: center;
+
+  .loading-more {
+    display: flex;
+    justify-content: center;
+  }
+
+  .login-prompt {
+    padding: 2rem;
+    color: var(--fnb-text-muted);
+
+    p {
+      margin-bottom: 0.75rem;
+      font-weight: 700;
+    }
+  }
+}
+</style>

--- a/app/pages/discovery/index.vue
+++ b/app/pages/discovery/index.vue
@@ -1,0 +1,10 @@
+<template lang="pug">
+div
+</template>
+
+<script lang="ts" setup>
+definePageMeta({
+  name: 'discovery-index',
+  middleware: () => navigateTo('/discovery/artworks', { replace: true }),
+})
+</script>

--- a/app/pages/discovery/novels.vue
+++ b/app/pages/discovery/novels.vue
@@ -1,0 +1,66 @@
+<template lang="pug">
+#discovery-novels
+  NovelList(
+    :list='discoveryStore.novelDiscoveryList',
+    :loading='discoveryStore.loadingNovelDiscovery'
+  )
+  .discover-footer(v-if='!discoveryStore.loadingNovelDiscovery')
+    .loading-more(v-if='userStore.isLoggedIn && discoveryStore.loadingMoreNovelDiscovery')
+      FnbSkeleton(block, height='2rem', width='200px')
+    .login-prompt(v-else-if='!userStore.isLoggedIn && discoveryStore.novelDiscoveryList.length')
+      p 登录后解锁无限浏览
+      FnbButton(
+        size='sm',
+        variant='primary',
+        tag='RouterLink',
+        to='/login?back=/discovery/novels'
+      )
+        template(#icon): ITablerLogin
+        | 登录
+    div(v-else-if='userStore.isLoggedIn', ref='scrollSentinel')
+</template>
+
+<script lang="ts" setup>
+import NovelList from '~/components/Novel/NovelList.vue'
+import { IconLogin as ITablerLogin } from '@tabler/icons-vue'
+import { useDiscoveryStore } from '~/stores/discovery'
+import { useUserStore } from '~/stores/session'
+
+const discoveryStore = useDiscoveryStore()
+const userStore = useUserStore()
+const scrollSentinel = ref<HTMLElement | null>(null)
+
+useIntersectionObserver(scrollSentinel, ([{ isIntersecting }]) => {
+  if (isIntersecting && userStore.isLoggedIn) {
+    discoveryStore.appendNovelDiscovery()
+  }
+})
+
+onMounted(() => {
+  if (!discoveryStore.novelDiscoveryList.length) {
+    discoveryStore.fetchNovelDiscovery()
+  }
+})
+</script>
+
+<style lang="scss" scoped>
+.discover-footer {
+  margin-top: 2rem;
+  text-align: center;
+
+  .loading-more {
+    display: flex;
+    justify-content: center;
+  }
+
+  .login-prompt {
+    padding: 2rem;
+    color: var(--fnb-text-muted);
+
+    p {
+      margin-bottom: 0.75rem;
+      font-weight: 700;
+    }
+  }
+}
+</style>

--- a/app/pages/discovery/users.vue
+++ b/app/pages/discovery/users.vue
@@ -64,11 +64,11 @@ useIntersectionObserver(scrollSentinel, ([{ isIntersecting }]) => {
   if (isIntersecting && userStore.isLoggedIn) loadMore()
 })
 
-// reset incremental reveal when the list is replaced by 换一批
+// reset incremental reveal whenever a fresh batch replaces the list (换一批 / mode change / first load)
 watch(
-  () => discoveryStore.userDiscoveryList.length,
-  (len, oldLen) => {
-    if (len < oldLen) visibleCount.value = PAGE_SIZE
+  () => discoveryStore.userDiscoveryEpoch,
+  () => {
+    visibleCount.value = PAGE_SIZE
   }
 )
 

--- a/app/pages/discovery/users.vue
+++ b/app/pages/discovery/users.vue
@@ -1,0 +1,120 @@
+<template lang="pug">
+#discovery-users
+  //- endpoint requires auth — show login prompt directly, no request
+  .login-prompt(v-if='!userStore.isLoggedIn')
+    p 推荐用户需要登录后查看
+    FnbButton(
+      size='sm',
+      variant='primary',
+      tag='RouterLink',
+      to='/login?back=/discovery/users'
+    )
+      template(#icon): ITablerLogin
+      | 登录
+
+  template(v-else)
+    .user-list(v-if='visibleUsers.length')
+      Card(v-for='u in visibleUsers', :key='u.userId')
+        FollowUserCard(:user='u')
+    .user-list(v-else-if='discoveryStore.loadingUserDiscovery')
+      Card(v-for='n in 4', :key='n')
+        FollowUserCard
+
+    .discover-footer(v-if='!discoveryStore.loadingUserDiscovery && visibleUsers.length')
+      .loading-more(v-if='discoveryStore.loadingMoreUserDiscovery')
+        FnbSkeleton(block, height='2rem', width='200px')
+      div(v-else-if='!atEnd', ref='scrollSentinel')
+</template>
+
+<script lang="ts" setup>
+import { IconLogin as ITablerLogin } from '@tabler/icons-vue'
+import { useDiscoveryStore } from '~/stores/discovery'
+import { useUserStore } from '~/stores/session'
+
+const discoveryStore = useDiscoveryStore()
+const userStore = useUserStore()
+const scrollSentinel = ref<HTMLElement | null>(null)
+
+const PAGE_SIZE = 10
+const visibleCount = ref(PAGE_SIZE)
+
+const visibleUsers = computed(() =>
+  discoveryStore.userDiscoveryList.slice(0, visibleCount.value)
+)
+
+// buffer fully revealed AND store says nothing more to fetch
+const atEnd = computed(
+  () =>
+    visibleCount.value >= discoveryStore.userDiscoveryList.length &&
+    discoveryStore.noMoreUserDiscovery
+)
+
+function loadMore() {
+  const buffered = discoveryStore.userDiscoveryList.length
+  if (visibleCount.value < buffered) {
+    // reveal more from the already-fetched buffer (no request)
+    visibleCount.value = Math.min(visibleCount.value + PAGE_SIZE, buffered)
+  } else if (!discoveryStore.noMoreUserDiscovery) {
+    // buffer exhausted — fetch the next batch of 100
+    discoveryStore.appendUserDiscovery()
+  }
+}
+
+useIntersectionObserver(scrollSentinel, ([{ isIntersecting }]) => {
+  if (isIntersecting && userStore.isLoggedIn) loadMore()
+})
+
+// reset incremental reveal when the list is replaced by 换一批
+watch(
+  () => discoveryStore.userDiscoveryList.length,
+  (len, oldLen) => {
+    if (len < oldLen) visibleCount.value = PAGE_SIZE
+  }
+)
+
+function maybeFetch() {
+  if (userStore.isLoggedIn && !discoveryStore.userDiscoveryList.length) {
+    discoveryStore.fetchUserDiscovery()
+  }
+}
+
+// session init is async — react to login state becoming available
+watch(() => userStore.isLoggedIn, () => maybeFetch(), { immediate: true })
+onMounted(maybeFetch)
+</script>
+
+<style lang="scss" scoped>
+.user-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+
+  // Skip render/layout/image-decode for off-screen cards (heavy DOM).
+  // `auto` remembers the real height after first paint to avoid scroll jump.
+  > * {
+    content-visibility: auto;
+    contain-intrinsic-size: auto 220px;
+  }
+}
+
+.discover-footer {
+  margin-top: 2rem;
+  text-align: center;
+
+  .loading-more {
+    display: flex;
+    justify-content: center;
+  }
+}
+
+.login-prompt {
+  padding: 2rem;
+  text-align: center;
+  color: var(--fnb-text-muted);
+
+  p {
+    margin-bottom: 0.75rem;
+    font-weight: 700;
+  }
+}
+</style>

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -114,20 +114,20 @@
             | {{ isDiscoveryLoading ? '加载中' : '换一批' }}
       ArtworkList(
         v-if='discoveryTab !== "novel"',
-        :list='homeStore.discoveryList',
-        :loading='homeStore.loadingDiscovery'
+        :list='discoveryStore.discoveryList',
+        :loading='discoveryStore.loadingDiscovery'
       )
       NovelList(
         v-else,
-        :list='homeStore.novelDiscoveryList',
-        :loading='homeStore.loadingNovelDiscovery'
+        :list='discoveryStore.novelDiscoveryList',
+        :loading='discoveryStore.loadingNovelDiscovery'
       )
 
       //- Infinite scroll sentinel / login prompt
-      .discover-footer(v-if='!homeStore.loadingDiscovery')
-        .loading-more(v-if='userStore.isLoggedIn && (discoveryTab === "novel" ? homeStore.loadingMoreNovelDiscovery : homeStore.loadingMoreDiscovery)')
+      .discover-footer(v-if='!discoveryStore.loadingDiscovery')
+        .loading-more(v-if='userStore.isLoggedIn && (discoveryTab === "novel" ? discoveryStore.loadingMoreNovelDiscovery : discoveryStore.loadingMoreDiscovery)')
           FnbSkeleton(block, height='2rem', width='200px')
-        .login-prompt(v-else-if='!userStore.isLoggedIn && homeStore.discoveryList.length')
+        .login-prompt(v-else-if='!userStore.isLoggedIn && discoveryStore.discoveryList.length')
           p 登录后解锁无限浏览
           FnbButton(
             size='sm',
@@ -152,6 +152,7 @@ import IFasRandom from '~icons/fa-solid/random'
 import IFasInfoCircle from '~icons/fa-solid/info-circle'
 import { IconChartBar as ITablerChartBar, IconUsers as ITablerUsers, IconCompass as ITablerCompass, IconBook as ITablerBook, IconTrophy as ITablerTrophy, IconLogin as ITablerLogin } from '@tabler/icons-vue'
 import { useHomeStore } from '~/stores/home'
+import { useDiscoveryStore } from '~/stores/discovery'
 import { useUserStore } from '~/stores/session'
 import { toRegularUrl } from '~/utils/pximg'
 import SiteLogo from '~/assets/PixivNow.svg'
@@ -166,6 +167,7 @@ useHead({
 const isShowBgInfo = ref(false)
 useBodyScrollLock(isShowBgInfo)
 const homeStore = useHomeStore()
+const discoveryStore = useDiscoveryStore()
 const userStore = useUserStore()
 const route = useRoute()
 const router = useRouter()
@@ -191,7 +193,7 @@ const savedDiscoveryMode = useLocalStorage('pixivnow:discovery-mode', 'all')
 const discoveryTab = ref((route.query.tab as string) || savedDiscoveryTab.value)
 const discoveryMode = ref((route.query.mode as string) || savedDiscoveryMode.value)
 
-homeStore.discoveryMode = discoveryMode.value
+discoveryStore.discoveryMode = discoveryMode.value
 
 function syncDiscoveryQuery() {
   const query = { ...route.query } as Record<string, string>
@@ -206,30 +208,30 @@ function changeDiscoveryTab(tab: string) {
   discoveryTab.value = tab
   savedDiscoveryTab.value = tab
   syncDiscoveryQuery()
-  if (tab === 'novel' && !homeStore.novelDiscoveryList.length) {
-    homeStore.fetchNovelDiscovery()
+  if (tab === 'novel' && !discoveryStore.novelDiscoveryList.length) {
+    discoveryStore.fetchNovelDiscovery()
   }
 }
 
 function changeDiscoveryMode(mode: string) {
   discoveryMode.value = mode
   savedDiscoveryMode.value = mode
-  homeStore.discoveryMode = mode
+  discoveryStore.discoveryMode = mode
   syncDiscoveryQuery()
   refreshDiscovery()
 }
 
 const isDiscoveryLoading = computed(() =>
   discoveryTab.value === 'novel'
-    ? homeStore.loadingNovelDiscovery
-    : homeStore.loadingDiscovery
+    ? discoveryStore.loadingNovelDiscovery
+    : discoveryStore.loadingDiscovery
 )
 
 function refreshDiscovery() {
   if (discoveryTab.value === 'novel') {
-    homeStore.fetchNovelDiscovery()
+    discoveryStore.fetchNovelDiscovery()
   } else {
-    homeStore.fetchDiscovery()
+    discoveryStore.fetchDiscovery()
   }
 }
 
@@ -241,9 +243,9 @@ function scrollToDiscovery() {
 useIntersectionObserver(scrollSentinel, ([{ isIntersecting }]) => {
   if (isIntersecting && userStore.isLoggedIn) {
     if (discoveryTab.value === 'novel') {
-      homeStore.appendNovelDiscovery()
+      discoveryStore.appendNovelDiscovery()
     } else {
-      homeStore.appendDiscovery()
+      discoveryStore.appendDiscovery()
     }
   }
 })
@@ -264,8 +266,8 @@ onMounted(() => {
   if (!homeStore.rankingList.length) {
     homeStore.fetchRanking()
   }
-  if (!homeStore.discoveryList.length) {
-    homeStore.fetchDiscovery()
+  if (!discoveryStore.discoveryList.length) {
+    discoveryStore.fetchDiscovery()
   }
 })
 </script>

--- a/app/stores/discovery.ts
+++ b/app/stores/discovery.ts
@@ -1,5 +1,5 @@
 import { defineStore } from 'pinia'
-import type { ArtworkInfo, NovelInfo } from '~/types'
+import type { ArtworkInfo, NovelInfo, UserListItem } from '~/types'
 
 export const useDiscoveryStore = defineStore('discovery', () => {
   const pixivClient = usePixivClient()
@@ -17,6 +17,12 @@ export const useDiscoveryStore = defineStore('discovery', () => {
   const loadingMoreNovelDiscovery = ref(false)
   const noMoreNovelDiscovery = ref(false)
   const novelDiscoverySeenIds = new Set<string>()
+
+  const userDiscoveryList = ref<UserListItem[]>([])
+  const loadingUserDiscovery = ref(false)
+  const loadingMoreUserDiscovery = ref(false)
+  const noMoreUserDiscovery = ref(false)
+  const userDiscoverySeenIds = new Set<string>()
 
   async function fetchDiscovery(): Promise<void> {
     if (loadingDiscovery.value) return
@@ -94,6 +100,41 @@ export const useDiscoveryStore = defineStore('discovery', () => {
     }
   }
 
+  async function fetchUserDiscovery(): Promise<void> {
+    if (loadingUserDiscovery.value) return
+    try {
+      loadingUserDiscovery.value = true
+      const users = await pixivClient.getDiscoveryUsers({ limit: 100 })
+      userDiscoverySeenIds.clear()
+      noMoreUserDiscovery.value = false
+      users.forEach((u) => userDiscoverySeenIds.add(u.userId))
+      userDiscoveryList.value = users
+    } catch (err) {
+      console.error('Failed to fetch user discovery', err)
+    } finally {
+      loadingUserDiscovery.value = false
+    }
+  }
+
+  async function appendUserDiscovery(): Promise<void> {
+    if (loadingMoreUserDiscovery.value || noMoreUserDiscovery.value) return
+    try {
+      loadingMoreUserDiscovery.value = true
+      const users = await pixivClient.getDiscoveryUsers({ limit: 20 })
+      const fresh = users.filter((u) => !userDiscoverySeenIds.has(u.userId))
+      if (!fresh.length) {
+        noMoreUserDiscovery.value = true
+        return
+      }
+      fresh.forEach((u) => userDiscoverySeenIds.add(u.userId))
+      userDiscoveryList.value = [...userDiscoveryList.value, ...fresh]
+    } catch (err) {
+      console.error('Failed to append user discovery', err)
+    } finally {
+      loadingMoreUserDiscovery.value = false
+    }
+  }
+
   return {
     discoveryMode,
     discoveryList,
@@ -108,5 +149,11 @@ export const useDiscoveryStore = defineStore('discovery', () => {
     noMoreNovelDiscovery,
     fetchNovelDiscovery,
     appendNovelDiscovery,
+    userDiscoveryList,
+    loadingUserDiscovery,
+    loadingMoreUserDiscovery,
+    noMoreUserDiscovery,
+    fetchUserDiscovery,
+    appendUserDiscovery,
   }
 })

--- a/app/stores/discovery.ts
+++ b/app/stores/discovery.ts
@@ -19,6 +19,7 @@ export const useDiscoveryStore = defineStore('discovery', () => {
   const novelDiscoverySeenIds = new Set<string>()
 
   const userDiscoveryList = ref<UserListItem[]>([])
+  const userDiscoveryEpoch = ref(0)
   const loadingUserDiscovery = ref(false)
   const loadingMoreUserDiscovery = ref(false)
   const noMoreUserDiscovery = ref(false)
@@ -109,6 +110,7 @@ export const useDiscoveryStore = defineStore('discovery', () => {
       noMoreUserDiscovery.value = false
       users.forEach((u) => userDiscoverySeenIds.add(u.userId))
       userDiscoveryList.value = users
+      userDiscoveryEpoch.value++
     } catch (err) {
       console.error('Failed to fetch user discovery', err)
     } finally {
@@ -150,6 +152,7 @@ export const useDiscoveryStore = defineStore('discovery', () => {
     fetchNovelDiscovery,
     appendNovelDiscovery,
     userDiscoveryList,
+    userDiscoveryEpoch,
     loadingUserDiscovery,
     loadingMoreUserDiscovery,
     noMoreUserDiscovery,

--- a/app/stores/discovery.ts
+++ b/app/stores/discovery.ts
@@ -1,0 +1,112 @@
+import { defineStore } from 'pinia'
+import type { ArtworkInfo, NovelInfo } from '~/types'
+
+export const useDiscoveryStore = defineStore('discovery', () => {
+  const pixivClient = usePixivClient()
+
+  const discoveryMode = ref('all')
+
+  const discoveryList = ref<ArtworkInfo[]>([])
+  const loadingDiscovery = ref(false)
+  const loadingMoreDiscovery = ref(false)
+  const noMoreDiscovery = ref(false)
+  const discoverySeenIds = new Set<string>()
+
+  const novelDiscoveryList = ref<NovelInfo[]>([])
+  const loadingNovelDiscovery = ref(false)
+  const loadingMoreNovelDiscovery = ref(false)
+  const noMoreNovelDiscovery = ref(false)
+  const novelDiscoverySeenIds = new Set<string>()
+
+  async function fetchDiscovery(): Promise<void> {
+    if (loadingDiscovery.value) return
+    try {
+      loadingDiscovery.value = true
+      const illusts = await pixivClient.getDiscovery({ mode: discoveryMode.value, limit: 60 })
+      discoverySeenIds.clear()
+      noMoreDiscovery.value = false
+      illusts.forEach((item) => discoverySeenIds.add(item.id))
+      discoveryList.value = illusts
+    } catch (err) {
+      console.error('Failed to fetch discovery', err)
+    } finally {
+      loadingDiscovery.value = false
+    }
+  }
+
+  async function appendDiscovery(): Promise<void> {
+    if (loadingMoreDiscovery.value || noMoreDiscovery.value) return
+    try {
+      loadingMoreDiscovery.value = true
+      const illusts = await pixivClient.getDiscovery({ mode: discoveryMode.value, limit: 60 })
+      const fresh = illusts.filter((item) => !discoverySeenIds.has(item.id))
+      if (!fresh.length) {
+        noMoreDiscovery.value = true
+        return
+      }
+      fresh.forEach((item) => discoverySeenIds.add(item.id))
+      discoveryList.value = [...discoveryList.value, ...fresh]
+    } catch (err) {
+      console.error('Failed to append discovery', err)
+    } finally {
+      loadingMoreDiscovery.value = false
+    }
+  }
+
+  async function fetchNovelDiscovery(): Promise<void> {
+    if (loadingNovelDiscovery.value) return
+    try {
+      loadingNovelDiscovery.value = true
+      const novels = await pixivClient.getNovelDiscovery({
+        mode: discoveryMode.value,
+        limit: 60,
+      })
+      novelDiscoverySeenIds.clear()
+      noMoreNovelDiscovery.value = false
+      novels.forEach((item) => novelDiscoverySeenIds.add(item.id))
+      novelDiscoveryList.value = novels
+    } catch (err) {
+      console.error('Failed to fetch novel discovery', err)
+    } finally {
+      loadingNovelDiscovery.value = false
+    }
+  }
+
+  async function appendNovelDiscovery(): Promise<void> {
+    if (loadingMoreNovelDiscovery.value || noMoreNovelDiscovery.value) return
+    try {
+      loadingMoreNovelDiscovery.value = true
+      const novels = await pixivClient.getNovelDiscovery({
+        mode: discoveryMode.value,
+        limit: 60,
+      })
+      const fresh = novels.filter((item) => !novelDiscoverySeenIds.has(item.id))
+      if (!fresh.length) {
+        noMoreNovelDiscovery.value = true
+        return
+      }
+      fresh.forEach((item) => novelDiscoverySeenIds.add(item.id))
+      novelDiscoveryList.value = [...novelDiscoveryList.value, ...fresh]
+    } catch (err) {
+      console.error('Failed to append novel discovery', err)
+    } finally {
+      loadingMoreNovelDiscovery.value = false
+    }
+  }
+
+  return {
+    discoveryMode,
+    discoveryList,
+    loadingDiscovery,
+    loadingMoreDiscovery,
+    noMoreDiscovery,
+    fetchDiscovery,
+    appendDiscovery,
+    novelDiscoveryList,
+    loadingNovelDiscovery,
+    loadingMoreNovelDiscovery,
+    noMoreNovelDiscovery,
+    fetchNovelDiscovery,
+    appendNovelDiscovery,
+  }
+})

--- a/app/stores/discovery.ts
+++ b/app/stores/discovery.ts
@@ -120,7 +120,7 @@ export const useDiscoveryStore = defineStore('discovery', () => {
     if (loadingMoreUserDiscovery.value || noMoreUserDiscovery.value) return
     try {
       loadingMoreUserDiscovery.value = true
-      const users = await pixivClient.getDiscoveryUsers({ limit: 20 })
+      const users = await pixivClient.getDiscoveryUsers({ limit: 100 })
       const fresh = users.filter((u) => !userDiscoverySeenIds.has(u.userId))
       if (!fresh.length) {
         noMoreUserDiscovery.value = true

--- a/app/stores/home.ts
+++ b/app/stores/home.ts
@@ -1,28 +1,15 @@
 import { defineStore } from 'pinia'
-import type { ArtworkInfo, NovelInfo, RankedArtworkInfo } from '~/types'
+import type { ArtworkInfo, RankedArtworkInfo } from '~/types'
 
 export const useHomeStore = defineStore('home', () => {
   const pixivClient = usePixivClient()
   const randomBg = ref<ArtworkInfo | null>(null)
-  const discoveryList = ref<ArtworkInfo[]>([])
-  const loadingDiscovery = ref(false)
 
   const rankingList = ref<RankedArtworkInfo[]>([])
   const loadingRanking = ref(false)
 
   const followingList = ref<ArtworkInfo[]>([])
   const loadingFollowing = ref(false)
-
-  const discoverySeenIds = new Set<string>()
-  const loadingMoreDiscovery = ref(false)
-  const noMoreDiscovery = ref(false)
-  const discoveryMode = ref('all')
-
-  const novelDiscoveryList = ref<NovelInfo[]>([])
-  const loadingNovelDiscovery = ref(false)
-  const loadingMoreNovelDiscovery = ref(false)
-  const noMoreNovelDiscovery = ref(false)
-  const novelDiscoverySeenIds = new Set<string>()
 
   async function fetchRandomBg(): Promise<void> {
     try {
@@ -32,22 +19,6 @@ export const useHomeStore = defineStore('home', () => {
       }
     } catch (err) {
       console.error(err)
-    }
-  }
-
-  async function fetchDiscovery(): Promise<void> {
-    if (loadingDiscovery.value) return
-    try {
-      loadingDiscovery.value = true
-      const illusts = await pixivClient.getDiscovery({ mode: discoveryMode.value, limit: 60 })
-      discoverySeenIds.clear()
-      noMoreDiscovery.value = false
-      illusts.forEach((item) => discoverySeenIds.add(item.id))
-      discoveryList.value = illusts
-    } catch (err) {
-      console.error('Failed to fetch discovery', err)
-    } finally {
-      loadingDiscovery.value = false
     }
   }
 
@@ -77,89 +48,14 @@ export const useHomeStore = defineStore('home', () => {
     }
   }
 
-  async function appendDiscovery(): Promise<void> {
-    if (loadingMoreDiscovery.value || noMoreDiscovery.value) return
-    try {
-      loadingMoreDiscovery.value = true
-      const illusts = await pixivClient.getDiscovery({ mode: discoveryMode.value, limit: 60 })
-      const fresh = illusts.filter((item) => !discoverySeenIds.has(item.id))
-      if (!fresh.length) {
-        noMoreDiscovery.value = true
-        return
-      }
-      fresh.forEach((item) => discoverySeenIds.add(item.id))
-      discoveryList.value = [...discoveryList.value, ...fresh]
-    } catch (err) {
-      console.error('Failed to append discovery', err)
-    } finally {
-      loadingMoreDiscovery.value = false
-    }
-  }
-
-  async function fetchNovelDiscovery(): Promise<void> {
-    if (loadingNovelDiscovery.value) return
-    try {
-      loadingNovelDiscovery.value = true
-      const novels = await pixivClient.getNovelDiscovery({
-        mode: discoveryMode.value,
-        limit: 60,
-      })
-      novelDiscoverySeenIds.clear()
-      noMoreNovelDiscovery.value = false
-      novels.forEach((item) => novelDiscoverySeenIds.add(item.id))
-      novelDiscoveryList.value = novels
-    } catch (err) {
-      console.error('Failed to fetch novel discovery', err)
-    } finally {
-      loadingNovelDiscovery.value = false
-    }
-  }
-
-  async function appendNovelDiscovery(): Promise<void> {
-    if (loadingMoreNovelDiscovery.value || noMoreNovelDiscovery.value) return
-    try {
-      loadingMoreNovelDiscovery.value = true
-      const novels = await pixivClient.getNovelDiscovery({
-        mode: discoveryMode.value,
-        limit: 60,
-      })
-      const fresh = novels.filter(
-        (item) => !novelDiscoverySeenIds.has(item.id)
-      )
-      if (!fresh.length) {
-        noMoreNovelDiscovery.value = true
-        return
-      }
-      fresh.forEach((item) => novelDiscoverySeenIds.add(item.id))
-      novelDiscoveryList.value = [...novelDiscoveryList.value, ...fresh]
-    } catch (err) {
-      console.error('Failed to append novel discovery', err)
-    } finally {
-      loadingMoreNovelDiscovery.value = false
-    }
-  }
-
   return {
     randomBg,
-    discoveryList,
-    loadingDiscovery,
     fetchRandomBg,
-    fetchDiscovery,
     rankingList,
     loadingRanking,
     fetchRanking,
     followingList,
     loadingFollowing,
     fetchFollowing,
-    loadingMoreDiscovery,
-    noMoreDiscovery,
-    appendDiscovery,
-    discoveryMode,
-    novelDiscoveryList,
-    loadingNovelDiscovery,
-    loadingMoreNovelDiscovery,
-    noMoreNovelDiscovery,
-    fetchNovelDiscovery,
-    appendNovelDiscovery,
   }
 })

--- a/docs/pixiv-web-api.md
+++ b/docs/pixiv-web-api.md
@@ -408,6 +408,54 @@ Query string example: `?novelIds[]=123&novelIds[]=456`
 }
 ```
 
+### 4.7 GET `/ajax/discovery/users`
+
+Get recommended users (personalized; requires authentication). Ignores the
+`mode` param — R18 visibility follows the account's own setting. No
+pagination; each call returns a fresh random batch.
+
+| Param   | Type   | Description                      |
+| ------- | ------ | -------------------------------- |
+| `limit` | number | Number of users (typically `20`) |
+| `lang`  | string | UI language, e.g. `zh`           |
+
+**Response** `body` (relational — join the three arrays):
+
+```jsonc
+{
+  "recommendedUsers": [
+    {
+      "userId": "117674738",
+      "recentIllustIds": ["145684188", "145364001"],
+      "recentNovelIds": []
+    }
+  ],
+  "users": [
+    {
+      "userId": "117674738",
+      "name": "...",
+      "image": "https://i.pximg.net/...",    // avatar (50px)
+      "imageBig": "https://i.pximg.net/...", // avatar (170px)
+      "comment": "...",
+      "isFollowed": false,
+      "followedBack": false,
+      "isMypixiv": false,
+      "isBlocking": false,
+      "premium": true,
+      "commission": { "acceptRequest": true }
+    }
+  ],
+  "thumbnails": {
+    "illust": [ /* ArtworkInfo[] — referenced by recentIllustIds */ ],
+    "novel":  [ /* NovelInfo[]  — referenced by recentNovelIds  */ ]
+  }
+}
+```
+
+Join `recommendedUsers[]` (order + which works) → `users[]` (by `userId`,
+user detail) → `thumbnails.illust` / `thumbnails.novel` (by id) to build a
+denormalized user-with-works list.
+
 ---
 
 ## 5. Search
@@ -1323,6 +1371,7 @@ Novel ranking item from `/ajax/ranking/novel`. Uses **snake_case** field names (
 | 4.4   | GET    | `/ajax/illust/recommend/illusts`         | Optional            | More artwork recommendations |
 | 4.5   | GET    | `/ajax/novel/{id}/recommend/init`        | Optional            | Novel recommendations        |
 | 4.6   | GET    | `/ajax/novel/recommend/novels`           | Optional            | More novel recommendations   |
+| 4.7   | GET    | `/ajax/discovery/users`                  | Required            | Recommended users            |
 | 5.1   | GET    | `/ajax/search/artworks/{keyword}`        | Optional            | Search artworks (combined)   |
 | 5.2   | GET    | `/ajax/search/illustrations/{keyword}`   | Optional            | Search illustrations         |
 | 5.3   | GET    | `/ajax/search/manga/{keyword}`           | Optional            | Search manga                 |

--- a/docs/superpowers/plans/2026-06-23-discovery-page.md
+++ b/docs/superpowers/plans/2026-06-23-discovery-page.md
@@ -460,7 +460,7 @@ import type { ArtworkInfo, NovelInfo, UserListItem } from '~/types'
     if (loadingMoreUserDiscovery.value || noMoreUserDiscovery.value) return
     try {
       loadingMoreUserDiscovery.value = true
-      const users = await pixivClient.getDiscoveryUsers({ limit: 20 })
+      const users = await pixivClient.getDiscoveryUsers({ limit: 100 })
       const fresh = users.filter((u) => !userDiscoverySeenIds.has(u.userId))
       if (!fresh.length) {
         noMoreUserDiscovery.value = true

--- a/docs/superpowers/plans/2026-06-23-discovery-page.md
+++ b/docs/superpowers/plans/2026-06-23-discovery-page.md
@@ -958,6 +958,13 @@ onMounted(maybeFetch)
   display: flex;
   flex-direction: column;
   gap: 1rem;
+
+  // Skip render/layout/image-decode for off-screen cards (heavy DOM).
+  // `auto` remembers the real height after first paint to avoid scroll jump.
+  > * {
+    content-visibility: auto;
+    contain-intrinsic-size: auto 220px;
+  }
 }
 
 .discover-footer {

--- a/docs/superpowers/plans/2026-06-23-discovery-page.md
+++ b/docs/superpowers/plans/2026-06-23-discovery-page.md
@@ -1,0 +1,1101 @@
+# 统一探索发现页 `/discovery` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 新增统一的 `/discovery` 页面（顶部 tab 切换 artworks/novels/users 三个子路由 + R18 开关），并把现有 discovery 逻辑从 `home.ts` 抽成独立 store。
+
+**Architecture:** Nuxt 嵌套路由（父布局 `discovery.vue` + 子页）。新建 `discovery` store 承载 artworks/novels/users 三类发现数据；首页改为引用新 store，行为保持不变。推荐用户接口在 `pixiv-client` 内做三段 join 适配成 `UserListItem`，从而零改动复用 `FollowUserCard`。
+
+**Tech Stack:** Nuxt 4 / Vue 3 SFC（Pug 模板 + SCSS）/ Pinia / axios / @vueuse/core。
+
+## Global Constraints
+
+- 代码风格：无分号、单引号、2 空格缩进、trailing comma（es5）。模板用 Pug（`lang="pug"`），样式用 SCSS（`lang="scss"`）。
+- 客户端 SPA（SSR 已禁用）。
+- 组件（`components/`）、Vue/Nuxt composable、Pinia store（`useXxxStore`）均自动导入；`~icons/*` 与 `@tabler/icons-vue` 需显式 import。
+- **项目无测试/lint 命令**（package.json 无 test）。验证方式：① 纯函数用 `node` 跑一次性脚本；② UI 用 dev server + 浏览器（可借助 Playwright MCP）；③ 最终 `pnpm build` 确认可编译。
+- **首页 `index.vue` 的可见行为必须完全不变**，抽 store 仅替换数据源。
+- 编写 Pug 模板前注意 `pug-vue-pitfalls`（class/属性特殊字符、slot 简写等）。
+- `discovery/users` 接口实测忽略 `mode`，users 子页不展示 R18 开关。
+
+---
+
+### Task 1: 推荐用户 API 适配层
+
+把 `/ajax/discovery/users` 的三段式返回 join 成 `UserListItem[]`。join 逻辑抽成纯函数 `buildDiscoveryUsers`（可独立用 node 验证），`pixiv-client` 调用它。
+
+**Files:**
+- Create: `app/api/discovery-users.ts`
+- Modify: `app/api/pixiv-client.ts`（在 `// ── Discovery & Recommendations` 区块末尾、`getRecommendMore` 之后新增方法；确认 `UserListItem` 已在顶部类型 import 中）
+
+**Interfaces:**
+- Produces:
+  - `buildDiscoveryUsers(body: DiscoveryUsersBody): UserListItem[]`
+  - `DiscoveryUsersBody`（raw 返回体类型）
+  - `PixivWebClient.getDiscoveryUsers(params: { limit?: number }): Promise<UserListItem[]>`
+
+- [ ] **Step 1: 创建纯 join 函数 `app/api/discovery-users.ts`**
+
+```ts
+import type { ArtworkInfo, NovelInfo, UserListItem } from '~/types'
+
+export interface DiscoveryUsersBody {
+  recommendedUsers: {
+    userId: string
+    recentIllustIds: string[]
+    recentNovelIds: string[]
+  }[]
+  users: {
+    userId: `${number}`
+    name: string
+    image: string
+    comment: string
+    isFollowed: boolean
+    followedBack: boolean
+    isMypixiv: boolean
+    isBlocking: boolean
+    commission?: { acceptRequest: boolean } | null
+  }[]
+  thumbnails: {
+    illust?: ArtworkInfo[]
+    novel?: NovelInfo[]
+  }
+}
+
+// Join the relational discovery/users payload into the denormalized
+// UserListItem shape consumed by FollowUserCard.
+export function buildDiscoveryUsers(body: DiscoveryUsersBody): UserListItem[] {
+  const userMap = new Map(body.users.map((u) => [u.userId, u]))
+  const illustMap = new Map((body.thumbnails.illust ?? []).map((i) => [i.id, i]))
+  const novelMap = new Map((body.thumbnails.novel ?? []).map((n) => [n.id, n]))
+
+  const result: UserListItem[] = []
+  for (const rec of body.recommendedUsers) {
+    const u = userMap.get(rec.userId as `${number}`)
+    if (!u) continue
+    result.push({
+      userId: u.userId,
+      userName: u.name,
+      profileImageUrl: u.image,
+      userComment: u.comment,
+      following: u.isFollowed,
+      followed: u.followedBack,
+      isBlocking: u.isBlocking,
+      isMypixiv: u.isMypixiv,
+      illusts: rec.recentIllustIds
+        .map((id) => illustMap.get(id as `${number}`))
+        .filter((x): x is ArtworkInfo => !!x),
+      novels: rec.recentNovelIds
+        .map((id) => novelMap.get(id as `${number}`))
+        .filter((x): x is NovelInfo => !!x),
+      acceptRequest: u.commission?.acceptRequest ?? false,
+    })
+  }
+  return result
+}
+```
+
+- [ ] **Step 2: 抓取真实样本作为测试 fixture**
+
+用调试 session 拉一份真实返回（不打印密钥）：
+
+```bash
+set -a && . ./.env && set +a && curl -s 'https://www.pixiv.net/ajax/discovery/users?limit=20&lang=zh' \
+  -H "Cookie: PHPSESSID=$DEBUG_PIXIV_PHPSESSID" \
+  -H 'User-Agent: Mozilla/5.0' \
+  -H 'Referer: https://www.pixiv.net/discovery/users' \
+  -H 'Accept: application/json' > /tmp/disc_users.json
+```
+
+Expected: 文件存在，`jq '.error' /tmp/disc_users.json` 输出 `false`。
+
+- [ ] **Step 3: 写并运行 join 验证脚本（先验证它能跑通真实数据）**
+
+```bash
+cat > /tmp/test-join.mts <<'EOF'
+import { readFileSync } from 'node:fs'
+import { buildDiscoveryUsers } from '/Users/xiaoyujun/GitRepositories/PixivNow/app/api/discovery-users.ts'
+
+const body = JSON.parse(readFileSync('/tmp/disc_users.json', 'utf8')).body
+const users = buildDiscoveryUsers(body)
+
+if (users.length === 0) throw new Error('FAIL: no users joined')
+const u = users[0]
+if (!u.userName) throw new Error('FAIL: userName not mapped from name')
+if (!u.profileImageUrl) throw new Error('FAIL: profileImageUrl not mapped from image')
+if (typeof u.following !== 'boolean') throw new Error('FAIL: following not mapped from isFollowed')
+if (!u.illusts.length) throw new Error('FAIL: illusts not joined from recentIllustIds')
+
+console.log('PASS users=' + users.length, 'name=' + u.userName, 'illusts=' + u.illusts.length)
+EOF
+node --experimental-strip-types /tmp/test-join.mts
+```
+
+Expected: 打印 `PASS users=20 name=... illusts=N`（N>0）。若 Node 版本 < 22.6，去掉 `--experimental-strip-types` 改用本地 `pnpm exec tsx`（若不可用则 Node 24 默认已支持类型剥离，直接 `node /tmp/test-join.mts`）。
+
+- [ ] **Step 4: 在 `pixiv-client.ts` 新增方法**
+
+确认文件顶部类型 import 含 `UserListItem`（若无则加入现有 `import type { ... } from '~/types'`），并在 `getRecommendMore` 之后插入：
+
+```ts
+  async getDiscoveryUsers(params: {
+    limit?: number
+  }): Promise<UserListItem[]> {
+    const { data } = await this.http.get<PixivResponse<DiscoveryUsersBody>>(
+      '/ajax/discovery/users',
+      {
+        params: {
+          limit: String(params.limit ?? 20),
+          lang: 'zh',
+        },
+      }
+    )
+    return buildDiscoveryUsers(this.unwrap(data))
+  }
+```
+
+在文件顶部 import 区加入：
+
+```ts
+import { buildDiscoveryUsers, type DiscoveryUsersBody } from './discovery-users'
+```
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add app/api/discovery-users.ts app/api/pixiv-client.ts
+git commit -m "feat(api): add getDiscoveryUsers adapter for discovery/users"
+```
+
+---
+
+### Task 2: 抽出 `discovery` store（保持首页行为不变）
+
+把 `home.ts` 中 artworks/novels 的 discovery state + actions 迁到新 `discovery` store，首页改为引用新 store。
+
+**Files:**
+- Create: `app/stores/discovery.ts`
+- Modify: `app/stores/home.ts`
+- Modify: `app/pages/index.vue`
+
+**Interfaces:**
+- Produces（`useDiscoveryStore`）：`discoveryMode`、`discoveryList`、`loadingDiscovery`、`loadingMoreDiscovery`、`noMoreDiscovery`、`novelDiscoveryList`、`loadingNovelDiscovery`、`loadingMoreNovelDiscovery`、`noMoreNovelDiscovery`、`fetchDiscovery()`、`appendDiscovery()`、`fetchNovelDiscovery()`、`appendNovelDiscovery()`
+- `home.ts` 保留：`randomBg`、`fetchRandomBg`、`rankingList`、`loadingRanking`、`fetchRanking`、`followingList`、`loadingFollowing`、`fetchFollowing`
+
+- [ ] **Step 1: 创建 `app/stores/discovery.ts`（从 home.ts 原样搬迁 4 个函数）**
+
+```ts
+import { defineStore } from 'pinia'
+import type { ArtworkInfo, NovelInfo } from '~/types'
+
+export const useDiscoveryStore = defineStore('discovery', () => {
+  const pixivClient = usePixivClient()
+
+  const discoveryMode = ref('all')
+
+  const discoveryList = ref<ArtworkInfo[]>([])
+  const loadingDiscovery = ref(false)
+  const loadingMoreDiscovery = ref(false)
+  const noMoreDiscovery = ref(false)
+  const discoverySeenIds = new Set<string>()
+
+  const novelDiscoveryList = ref<NovelInfo[]>([])
+  const loadingNovelDiscovery = ref(false)
+  const loadingMoreNovelDiscovery = ref(false)
+  const noMoreNovelDiscovery = ref(false)
+  const novelDiscoverySeenIds = new Set<string>()
+
+  async function fetchDiscovery(): Promise<void> {
+    if (loadingDiscovery.value) return
+    try {
+      loadingDiscovery.value = true
+      const illusts = await pixivClient.getDiscovery({ mode: discoveryMode.value, limit: 60 })
+      discoverySeenIds.clear()
+      noMoreDiscovery.value = false
+      illusts.forEach((item) => discoverySeenIds.add(item.id))
+      discoveryList.value = illusts
+    } catch (err) {
+      console.error('Failed to fetch discovery', err)
+    } finally {
+      loadingDiscovery.value = false
+    }
+  }
+
+  async function appendDiscovery(): Promise<void> {
+    if (loadingMoreDiscovery.value || noMoreDiscovery.value) return
+    try {
+      loadingMoreDiscovery.value = true
+      const illusts = await pixivClient.getDiscovery({ mode: discoveryMode.value, limit: 60 })
+      const fresh = illusts.filter((item) => !discoverySeenIds.has(item.id))
+      if (!fresh.length) {
+        noMoreDiscovery.value = true
+        return
+      }
+      fresh.forEach((item) => discoverySeenIds.add(item.id))
+      discoveryList.value = [...discoveryList.value, ...fresh]
+    } catch (err) {
+      console.error('Failed to append discovery', err)
+    } finally {
+      loadingMoreDiscovery.value = false
+    }
+  }
+
+  async function fetchNovelDiscovery(): Promise<void> {
+    if (loadingNovelDiscovery.value) return
+    try {
+      loadingNovelDiscovery.value = true
+      const novels = await pixivClient.getNovelDiscovery({
+        mode: discoveryMode.value,
+        limit: 60,
+      })
+      novelDiscoverySeenIds.clear()
+      noMoreNovelDiscovery.value = false
+      novels.forEach((item) => novelDiscoverySeenIds.add(item.id))
+      novelDiscoveryList.value = novels
+    } catch (err) {
+      console.error('Failed to fetch novel discovery', err)
+    } finally {
+      loadingNovelDiscovery.value = false
+    }
+  }
+
+  async function appendNovelDiscovery(): Promise<void> {
+    if (loadingMoreNovelDiscovery.value || noMoreNovelDiscovery.value) return
+    try {
+      loadingMoreNovelDiscovery.value = true
+      const novels = await pixivClient.getNovelDiscovery({
+        mode: discoveryMode.value,
+        limit: 60,
+      })
+      const fresh = novels.filter((item) => !novelDiscoverySeenIds.has(item.id))
+      if (!fresh.length) {
+        noMoreNovelDiscovery.value = true
+        return
+      }
+      fresh.forEach((item) => novelDiscoverySeenIds.add(item.id))
+      novelDiscoveryList.value = [...novelDiscoveryList.value, ...fresh]
+    } catch (err) {
+      console.error('Failed to append novel discovery', err)
+    } finally {
+      loadingMoreNovelDiscovery.value = false
+    }
+  }
+
+  return {
+    discoveryMode,
+    discoveryList,
+    loadingDiscovery,
+    loadingMoreDiscovery,
+    noMoreDiscovery,
+    fetchDiscovery,
+    appendDiscovery,
+    novelDiscoveryList,
+    loadingNovelDiscovery,
+    loadingMoreNovelDiscovery,
+    noMoreNovelDiscovery,
+    fetchNovelDiscovery,
+    appendNovelDiscovery,
+  }
+})
+```
+
+- [ ] **Step 2: 精简 `app/stores/home.ts`（移除已迁出的 discovery 部分）**
+
+将 `home.ts` 整体替换为：
+
+```ts
+import { defineStore } from 'pinia'
+import type { ArtworkInfo, RankedArtworkInfo } from '~/types'
+
+export const useHomeStore = defineStore('home', () => {
+  const pixivClient = usePixivClient()
+  const randomBg = ref<ArtworkInfo | null>(null)
+
+  const rankingList = ref<RankedArtworkInfo[]>([])
+  const loadingRanking = ref(false)
+
+  const followingList = ref<ArtworkInfo[]>([])
+  const loadingFollowing = ref(false)
+
+  async function fetchRandomBg(): Promise<void> {
+    try {
+      const illusts = await pixivClient.getDiscovery({ mode: 'safe', limit: 1 })
+      if (illusts.length) {
+        randomBg.value = illusts[0]!
+      }
+    } catch (err) {
+      console.error(err)
+    }
+  }
+
+  async function fetchRanking(): Promise<void> {
+    if (loadingRanking.value) return
+    try {
+      loadingRanking.value = true
+      const data = await pixivClient.getRanking({ mode: 'daily', content: 'all', p: 1 })
+      rankingList.value = data.contents.slice(0, 5)
+    } catch (err) {
+      console.error('Failed to fetch ranking', err)
+    } finally {
+      loadingRanking.value = false
+    }
+  }
+
+  async function fetchFollowing(): Promise<void> {
+    if (loadingFollowing.value) return
+    try {
+      loadingFollowing.value = true
+      const data = await pixivClient.getFollowLatest({ p: 1, mode: 'all' })
+      followingList.value = data.thumbnails.illust
+    } catch (err) {
+      console.error('Failed to fetch following', err)
+    } finally {
+      loadingFollowing.value = false
+    }
+  }
+
+  return {
+    randomBg,
+    fetchRandomBg,
+    rankingList,
+    loadingRanking,
+    fetchRanking,
+    followingList,
+    loadingFollowing,
+    fetchFollowing,
+  }
+})
+```
+
+- [ ] **Step 3: 在 `app/pages/index.vue` 把 discovery 数据源切到新 store**
+
+在 `<script setup>` import 区加入：
+
+```ts
+import { useDiscoveryStore } from '~/stores/discovery'
+```
+
+在 `const homeStore = useHomeStore()` 下一行加入：
+
+```ts
+const discoveryStore = useDiscoveryStore()
+```
+
+然后把以下对 discovery 相关属性/方法的引用从 `homeStore.` 改为 `discoveryStore.`（其余 `homeStore.` 引用保持不变）：
+
+- template 内：`homeStore.discoveryList` → `discoveryStore.discoveryList`；`homeStore.loadingDiscovery` → `discoveryStore.loadingDiscovery`；`homeStore.novelDiscoveryList` → `discoveryStore.novelDiscoveryList`；`homeStore.loadingNovelDiscovery` → `discoveryStore.loadingNovelDiscovery`；`homeStore.loadingMoreNovelDiscovery` → `discoveryStore.loadingMoreNovelDiscovery`；`homeStore.loadingMoreDiscovery` → `discoveryStore.loadingMoreDiscovery`
+- script 内：`homeStore.discoveryMode`（2 处）、`homeStore.novelDiscoveryList`、`homeStore.fetchNovelDiscovery`、`homeStore.fetchDiscovery`（2 处）、`homeStore.appendNovelDiscovery`、`homeStore.appendDiscovery`、以及 `isDiscoveryLoading` 内的 `homeStore.loadingNovelDiscovery`/`homeStore.loadingDiscovery` —— 全部改为 `discoveryStore.`
+
+保持 `homeStore.randomBg` / `fetchRandomBg` / `rankingList` / `loadingRanking` / `fetchRanking` / `followingList` / `loadingFollowing` / `fetchFollowing` 不变。
+
+- [ ] **Step 4: 验证首页行为完全不变**
+
+启动 dev server（若未运行）：`pnpm dev`，浏览器打开 `http://localhost:3000/`，逐项确认：
+
+Expected:
+- 「探索发现」区块加载出插画列表
+- 切到「小说」tab 正常加载小说
+- 切换 R18 下拉（混池/全年龄/R18）会重新拉取
+- 「换一批」按钮可刷新
+- 滚到底自动加载更多（已登录时）
+- URL query（`?tab=`/`?mode=`）与 localStorage 记忆行为与改动前一致
+- 浏览器 console 无新增报错
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add app/stores/discovery.ts app/stores/home.ts app/pages/index.vue
+git commit -m "refactor(store): extract discovery store from home, keep home behavior intact"
+```
+
+---
+
+### Task 3: discovery store 增加推荐用户
+
+**Files:**
+- Modify: `app/stores/discovery.ts`
+
+**Interfaces:**
+- Consumes: `pixivClient.getDiscoveryUsers({ limit })`（Task 1）
+- Produces: `userDiscoveryList`、`loadingUserDiscovery`、`loadingMoreUserDiscovery`、`noMoreUserDiscovery`、`fetchUserDiscovery()`、`appendUserDiscovery()`
+
+- [ ] **Step 1: 顶部 import 加上 `UserListItem`**
+
+```ts
+import type { ArtworkInfo, NovelInfo, UserListItem } from '~/types'
+```
+
+- [ ] **Step 2: 在 novel 相关 state 之后新增 user state**
+
+```ts
+  const userDiscoveryList = ref<UserListItem[]>([])
+  const loadingUserDiscovery = ref(false)
+  const loadingMoreUserDiscovery = ref(false)
+  const noMoreUserDiscovery = ref(false)
+  const userDiscoverySeenIds = new Set<string>()
+```
+
+- [ ] **Step 3: 在 `appendNovelDiscovery` 之后新增两个 action**
+
+```ts
+  async function fetchUserDiscovery(): Promise<void> {
+    if (loadingUserDiscovery.value) return
+    try {
+      loadingUserDiscovery.value = true
+      const users = await pixivClient.getDiscoveryUsers({ limit: 20 })
+      userDiscoverySeenIds.clear()
+      noMoreUserDiscovery.value = false
+      users.forEach((u) => userDiscoverySeenIds.add(u.userId))
+      userDiscoveryList.value = users
+    } catch (err) {
+      console.error('Failed to fetch user discovery', err)
+    } finally {
+      loadingUserDiscovery.value = false
+    }
+  }
+
+  async function appendUserDiscovery(): Promise<void> {
+    if (loadingMoreUserDiscovery.value || noMoreUserDiscovery.value) return
+    try {
+      loadingMoreUserDiscovery.value = true
+      const users = await pixivClient.getDiscoveryUsers({ limit: 20 })
+      const fresh = users.filter((u) => !userDiscoverySeenIds.has(u.userId))
+      if (!fresh.length) {
+        noMoreUserDiscovery.value = true
+        return
+      }
+      fresh.forEach((u) => userDiscoverySeenIds.add(u.userId))
+      userDiscoveryList.value = [...userDiscoveryList.value, ...fresh]
+    } catch (err) {
+      console.error('Failed to append user discovery', err)
+    } finally {
+      loadingMoreUserDiscovery.value = false
+    }
+  }
+```
+
+- [ ] **Step 4: 在 return 中导出新成员**
+
+在 `return { ... }` 内追加：
+
+```ts
+    userDiscoveryList,
+    loadingUserDiscovery,
+    loadingMoreUserDiscovery,
+    noMoreUserDiscovery,
+    fetchUserDiscovery,
+    appendUserDiscovery,
+```
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add app/stores/discovery.ts
+git commit -m "feat(store): add user discovery actions"
+```
+
+---
+
+### Task 4: `/discovery` 父布局 + 默认重定向
+
+**Files:**
+- Create: `app/pages/discovery.vue`
+- Create: `app/pages/discovery/index.vue`
+
+**Interfaces:**
+- Consumes: `useDiscoveryStore`（mode + fetch*）、`useUserStore`
+- Produces: 父布局含 `<NuxtPage/>`；顶部 tab（router-link）、R18 `FnbSelect`（users 子页隐藏）、「换一批」按钮
+
+- [ ] **Step 1: 创建 `app/pages/discovery.vue`**
+
+```vue
+<template lang="pug">
+#discovery-view.body-inner
+  .discover-header
+    h2
+      FnbIcon: ITablerCompass
+      |  探索发现
+    .discover-controls
+      .tab-nav
+        RouterLink.tab-item(
+          v-for='t in tabs',
+          :key='t.key',
+          :to='t.to',
+          :class='{ active: activeKey === t.key }'
+        ) {{ t.label }}
+      FnbSelect(
+        v-if='showModeSelect && userStore.isLoggedIn',
+        :model-value='discoveryMode',
+        :options='discoveryModeOptions',
+        @update:model-value='changeMode'
+      )
+      FnbButton(:loading='isLoading', @click='refresh', size='sm')
+        template(#icon): IFasRandom
+        | {{ isLoading ? '加载中' : '换一批' }}
+  NuxtPage
+</template>
+
+<script lang="ts" setup>
+import IFasRandom from '~icons/fa-solid/random'
+import { IconCompass as ITablerCompass } from '@tabler/icons-vue'
+import { useDiscoveryStore } from '~/stores/discovery'
+import { useUserStore } from '~/stores/session'
+import { setTitle } from '~/utils/setTitle'
+
+definePageMeta({ name: 'discovery' })
+
+const discoveryStore = useDiscoveryStore()
+const userStore = useUserStore()
+const route = useRoute()
+
+const discoveryModeOptions = [
+  { label: '混池', value: 'all' },
+  { label: '全年龄', value: 'safe' },
+  { label: 'R18', value: 'r18' },
+]
+
+const savedDiscoveryMode = useLocalStorage('pixivnow:discovery-mode', 'all')
+const discoveryMode = ref(savedDiscoveryMode.value)
+discoveryStore.discoveryMode = discoveryMode.value
+
+const tabs = [
+  { key: 'artworks', label: '插画·漫画', to: '/discovery/artworks' },
+  { key: 'novels', label: '小说', to: '/discovery/novels' },
+  { key: 'users', label: '用户', to: '/discovery/users' },
+]
+
+const activeKey = computed(() => {
+  if (route.path.startsWith('/discovery/novels')) return 'novels'
+  if (route.path.startsWith('/discovery/users')) return 'users'
+  return 'artworks'
+})
+
+const showModeSelect = computed(() => activeKey.value !== 'users')
+
+const isLoading = computed(() => {
+  if (activeKey.value === 'novels') return discoveryStore.loadingNovelDiscovery
+  if (activeKey.value === 'users') return discoveryStore.loadingUserDiscovery
+  return discoveryStore.loadingDiscovery
+})
+
+function refresh() {
+  if (activeKey.value === 'novels') discoveryStore.fetchNovelDiscovery()
+  else if (activeKey.value === 'users') discoveryStore.fetchUserDiscovery()
+  else discoveryStore.fetchDiscovery()
+}
+
+function changeMode(mode: string) {
+  discoveryMode.value = mode
+  savedDiscoveryMode.value = mode
+  discoveryStore.discoveryMode = mode
+  refresh()
+}
+
+onMounted(() => setTitle('探索发现'))
+</script>
+
+<style lang="scss" scoped>
+.discover-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-bottom: 1rem;
+
+  h2 {
+    font-family: var(--fnb-font-display);
+    font-weight: 900;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin: 0;
+  }
+}
+
+.discover-controls {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.tab-nav {
+  display: flex;
+  gap: 0.25rem;
+}
+
+.tab-item {
+  padding: 0.3rem 1rem;
+  border: 3px solid transparent;
+  border-radius: var(--fnb-radius-sm);
+  font-weight: 700;
+  color: var(--fnb-text-muted);
+  text-decoration: none;
+  transition: color 150ms, background 150ms;
+
+  &:hover {
+    color: var(--fnb-text);
+    background: color-mix(in srgb, var(--fnb-brand) 15%, var(--fnb-surface));
+  }
+
+  &.active {
+    color: #fff;
+    background: var(--fnb-brand);
+    border-color: var(--fnb-border);
+  }
+}
+</style>
+```
+
+- [ ] **Step 2: 创建 `app/pages/discovery/index.vue`（`/discovery` 重定向到 artworks）**
+
+```vue
+<template lang="pug">
+div
+</template>
+
+<script lang="ts" setup>
+definePageMeta({
+  name: 'discovery-index',
+  middleware: () => navigateTo('/discovery/artworks', { replace: true }),
+})
+</script>
+```
+
+- [ ] **Step 3: 验证（子页尚未建，预期空白但布局/重定向可见）**
+
+`pnpm dev`，浏览器打开 `http://localhost:3000/discovery`。
+
+Expected:
+- URL 跳转到 `/discovery/artworks`
+- 顶部出现「探索发现」标题 + 三个 tab（插画·漫画/小说/用户）+「换一批」按钮
+- 点击不同 tab，对应 tab 高亮（active 样式）
+- 切到「用户」tab 时 R18 下拉消失，切回其他 tab 又出现
+- 下方内容区暂为空（子页 Task 5/6 实现），console 无报错
+
+- [ ] **Step 4: 提交**
+
+```bash
+git add app/pages/discovery.vue app/pages/discovery/index.vue
+git commit -m "feat(discovery): add /discovery parent layout with tabs and mode switch"
+```
+
+---
+
+### Task 5: artworks 与 novels 子页
+
+两个子页结构对称，分别消费 discovery store 的 artworks/novels 数据 + 无限滚动。
+
+**Files:**
+- Create: `app/pages/discovery/artworks.vue`
+- Create: `app/pages/discovery/novels.vue`
+
+**Interfaces:**
+- Consumes: `useDiscoveryStore`（`discoveryList`/`loadingDiscovery`/`loadingMoreDiscovery`/`appendDiscovery`/`fetchDiscovery` 及 novel 对应项）、`useUserStore`、`ArtworkList`、`NovelList`
+
+- [ ] **Step 1: 创建 `app/pages/discovery/artworks.vue`**
+
+```vue
+<template lang="pug">
+#discovery-artworks
+  ArtworkList(
+    :list='discoveryStore.discoveryList',
+    :loading='discoveryStore.loadingDiscovery'
+  )
+  .discover-footer(v-if='!discoveryStore.loadingDiscovery')
+    .loading-more(v-if='userStore.isLoggedIn && discoveryStore.loadingMoreDiscovery')
+      FnbSkeleton(block, height='2rem', width='200px')
+    .login-prompt(v-else-if='!userStore.isLoggedIn && discoveryStore.discoveryList.length')
+      p 登录后解锁无限浏览
+      FnbButton(
+        size='sm',
+        variant='primary',
+        tag='RouterLink',
+        to='/login?back=/discovery/artworks'
+      )
+        template(#icon): ITablerLogin
+        | 登录
+    div(v-else-if='userStore.isLoggedIn', ref='scrollSentinel')
+</template>
+
+<script lang="ts" setup>
+import ArtworkList from '~/components/Artwork/ArtworkList.vue'
+import { IconLogin as ITablerLogin } from '@tabler/icons-vue'
+import { useDiscoveryStore } from '~/stores/discovery'
+import { useUserStore } from '~/stores/session'
+
+const discoveryStore = useDiscoveryStore()
+const userStore = useUserStore()
+const scrollSentinel = ref<HTMLElement | null>(null)
+
+useIntersectionObserver(scrollSentinel, ([{ isIntersecting }]) => {
+  if (isIntersecting && userStore.isLoggedIn) {
+    discoveryStore.appendDiscovery()
+  }
+})
+
+onMounted(() => {
+  if (!discoveryStore.discoveryList.length) {
+    discoveryStore.fetchDiscovery()
+  }
+})
+</script>
+
+<style lang="scss" scoped>
+.discover-footer {
+  margin-top: 2rem;
+  text-align: center;
+
+  .loading-more {
+    display: flex;
+    justify-content: center;
+  }
+
+  .login-prompt {
+    padding: 2rem;
+    color: var(--fnb-text-muted);
+
+    p {
+      margin-bottom: 0.75rem;
+      font-weight: 700;
+    }
+  }
+}
+</style>
+```
+
+- [ ] **Step 2: 创建 `app/pages/discovery/novels.vue`**
+
+```vue
+<template lang="pug">
+#discovery-novels
+  NovelList(
+    :list='discoveryStore.novelDiscoveryList',
+    :loading='discoveryStore.loadingNovelDiscovery'
+  )
+  .discover-footer(v-if='!discoveryStore.loadingNovelDiscovery')
+    .loading-more(v-if='userStore.isLoggedIn && discoveryStore.loadingMoreNovelDiscovery')
+      FnbSkeleton(block, height='2rem', width='200px')
+    .login-prompt(v-else-if='!userStore.isLoggedIn && discoveryStore.novelDiscoveryList.length')
+      p 登录后解锁无限浏览
+      FnbButton(
+        size='sm',
+        variant='primary',
+        tag='RouterLink',
+        to='/login?back=/discovery/novels'
+      )
+        template(#icon): ITablerLogin
+        | 登录
+    div(v-else-if='userStore.isLoggedIn', ref='scrollSentinel')
+</template>
+
+<script lang="ts" setup>
+import NovelList from '~/components/Novel/NovelList.vue'
+import { IconLogin as ITablerLogin } from '@tabler/icons-vue'
+import { useDiscoveryStore } from '~/stores/discovery'
+import { useUserStore } from '~/stores/session'
+
+const discoveryStore = useDiscoveryStore()
+const userStore = useUserStore()
+const scrollSentinel = ref<HTMLElement | null>(null)
+
+useIntersectionObserver(scrollSentinel, ([{ isIntersecting }]) => {
+  if (isIntersecting && userStore.isLoggedIn) {
+    discoveryStore.appendNovelDiscovery()
+  }
+})
+
+onMounted(() => {
+  if (!discoveryStore.novelDiscoveryList.length) {
+    discoveryStore.fetchNovelDiscovery()
+  }
+})
+</script>
+
+<style lang="scss" scoped>
+.discover-footer {
+  margin-top: 2rem;
+  text-align: center;
+
+  .loading-more {
+    display: flex;
+    justify-content: center;
+  }
+
+  .login-prompt {
+    padding: 2rem;
+    color: var(--fnb-text-muted);
+
+    p {
+      margin-bottom: 0.75rem;
+      font-weight: 700;
+    }
+  }
+}
+</style>
+```
+
+- [ ] **Step 3: 验证**
+
+`pnpm dev`，浏览器：
+- `http://localhost:3000/discovery/artworks` → 加载插画列表；切换 R18 下拉重新拉取；「换一批」刷新；滚到底自动加载更多（已登录）
+- `http://localhost:3000/discovery/novels` → 加载小说列表，同样支持模式切换/换一批/无限滚动
+
+Expected: 两个子页均正常渲染，console 无报错。
+
+- [ ] **Step 4: 提交**
+
+```bash
+git add app/pages/discovery/artworks.vue app/pages/discovery/novels.vue
+git commit -m "feat(discovery): add artworks and novels sub-pages"
+```
+
+---
+
+### Task 6: users 子页（复用 FollowUserCard）
+
+**Files:**
+- Create: `app/pages/discovery/users.vue`
+
+**Interfaces:**
+- Consumes: `useDiscoveryStore`（`userDiscoveryList`/`loadingUserDiscovery`/`loadingMoreUserDiscovery`/`fetchUserDiscovery`/`appendUserDiscovery`）、`useUserStore`、`Card`、`FollowUserCard`
+
+- [ ] **Step 1: 创建 `app/pages/discovery/users.vue`**
+
+```vue
+<template lang="pug">
+#discovery-users
+  .user-list(v-if='discoveryStore.userDiscoveryList.length')
+    Card(v-for='u in discoveryStore.userDiscoveryList', :key='u.userId')
+      FollowUserCard(:user='u')
+  .user-list(v-else-if='discoveryStore.loadingUserDiscovery')
+    Card(v-for='n in 4', :key='n')
+      FollowUserCard
+  .discover-footer(v-if='!discoveryStore.loadingUserDiscovery')
+    .loading-more(v-if='userStore.isLoggedIn && discoveryStore.loadingMoreUserDiscovery')
+      FnbSkeleton(block, height='2rem', width='200px')
+    .login-prompt(v-else-if='!userStore.isLoggedIn')
+      p 登录后查看推荐用户
+      FnbButton(
+        size='sm',
+        variant='primary',
+        tag='RouterLink',
+        to='/login?back=/discovery/users'
+      )
+        template(#icon): ITablerLogin
+        | 登录
+    div(v-else-if='userStore.isLoggedIn', ref='scrollSentinel')
+</template>
+
+<script lang="ts" setup>
+import { IconLogin as ITablerLogin } from '@tabler/icons-vue'
+import { useDiscoveryStore } from '~/stores/discovery'
+import { useUserStore } from '~/stores/session'
+
+const discoveryStore = useDiscoveryStore()
+const userStore = useUserStore()
+const scrollSentinel = ref<HTMLElement | null>(null)
+
+useIntersectionObserver(scrollSentinel, ([{ isIntersecting }]) => {
+  if (isIntersecting && userStore.isLoggedIn) {
+    discoveryStore.appendUserDiscovery()
+  }
+})
+
+function maybeFetch() {
+  if (userStore.isLoggedIn && !discoveryStore.userDiscoveryList.length) {
+    discoveryStore.fetchUserDiscovery()
+  }
+}
+
+// session init is async — react to login state becoming available
+watch(() => userStore.isLoggedIn, () => maybeFetch(), { immediate: true })
+onMounted(maybeFetch)
+</script>
+
+<style lang="scss" scoped>
+.user-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.discover-footer {
+  margin-top: 2rem;
+  text-align: center;
+
+  .loading-more {
+    display: flex;
+    justify-content: center;
+  }
+
+  .login-prompt {
+    padding: 2rem;
+    color: var(--fnb-text-muted);
+
+    p {
+      margin-bottom: 0.75rem;
+      font-weight: 700;
+    }
+  }
+}
+</style>
+```
+
+- [ ] **Step 2: 验证（核心功能，需登录态）**
+
+确保浏览器已登录（有 PHPSESSID），打开 `http://localhost:3000/discovery/users`。
+
+Expected:
+- 渲染推荐用户卡片列表（头像 / 用户名 / 自述 / 4 张作品预览）
+- 关注/取关按钮可点击且状态切换
+- 滚到底自动「换一批」追加（按 userId 去重）
+- 顶部无 R18 下拉
+- 未登录时显示「登录后查看推荐用户」提示
+- console 无报错
+
+- [ ] **Step 3: 提交**
+
+```bash
+git add app/pages/discovery/users.vue
+git commit -m "feat(discovery): add recommended users sub-page"
+```
+
+---
+
+### Task 7: 启用侧边栏「探索发现」入口
+
+**Files:**
+- Modify: `app/components/SideNav/SideNav.vue:15`
+
+- [ ] **Step 1: 替换禁用占位为可用链接**
+
+将：
+
+```pug
+          SideNavListLink.not-allowed(link='' text='探索发现')
+            IFasImage.link-icon
+```
+
+改为：
+
+```pug
+          SideNavListLink(link='/discovery' text='探索发现')
+            IFasImage.link-icon
+```
+
+- [ ] **Step 2: 验证**
+
+`pnpm dev`，打开侧边栏，点击「探索发现」。
+
+Expected: 跳转到 `/discovery`（再重定向到 `/discovery/artworks`），不再有删除线/`not-allowed` 样式。
+
+- [ ] **Step 3: 提交**
+
+```bash
+git add app/components/SideNav/SideNav.vue
+git commit -m "feat(nav): enable discovery entry in side nav"
+```
+
+---
+
+### Task 8: 补充 API 文档
+
+**Files:**
+- Modify: `docs/pixiv-web-api.md`（在 §4 Discovery 相关章节后新增；若无独立 Discovery 章节，则置于 §8 Following 之前，并在末尾 Endpoint Summary 表追加一行）
+
+- [ ] **Step 1: 按既有格式新增章节**
+
+```markdown
+### GET `/ajax/discovery/users`
+
+Get recommended users (personalized; requires authentication). Ignores the
+`mode` param — R18 visibility follows the account's own setting. No
+pagination; each call returns a fresh random batch.
+
+| Param   | Type   | Description                       |
+| ------- | ------ | --------------------------------- |
+| `limit` | number | Number of users (typically `20`)  |
+| `lang`  | string | UI language, e.g. `zh`            |
+
+**Response** `body` (relational — join the three arrays):
+
+```jsonc
+{
+  "recommendedUsers": [
+    {
+      "userId": "117674738",
+      "recentIllustIds": ["145684188", "145364001"],
+      "recentNovelIds": []
+    }
+  ],
+  "users": [
+    {
+      "userId": "117674738",
+      "name": "...",
+      "image": "https://i.pximg.net/...",   // avatar (50px)
+      "imageBig": "https://i.pximg.net/...", // avatar (170px)
+      "comment": "...",
+      "isFollowed": false,
+      "followedBack": false,
+      "isMypixiv": false,
+      "isBlocking": false,
+      "premium": true,
+      "commission": { "acceptRequest": true }
+    }
+  ],
+  "thumbnails": {
+    "illust": [ /* ArtworkInfo[] — referenced by recentIllustIds */ ],
+    "novel":  [ /* NovelInfo[]  — referenced by recentNovelIds  */ ]
+  }
+}
+```
+
+Join `recommendedUsers[]` (order + which works) → `users[]` (by `userId`,
+user detail) → `thumbnails.illust` / `thumbnails.novel` (by id) to build a
+denormalized user-with-works list.
+```
+
+并在文末 Endpoint Summary 表追加：
+
+```markdown
+| GET    | `/ajax/discovery/users` | Recommended users |
+```
+
+- [ ] **Step 2: 验证**
+
+`grep -n "discovery/users" docs/pixiv-web-api.md`
+
+Expected: 命中新增章节标题与 summary 行。
+
+- [ ] **Step 3: 提交**
+
+```bash
+git add docs/pixiv-web-api.md
+git commit -m "docs: document /ajax/discovery/users endpoint"
+```
+
+---
+
+## 收尾验证
+
+- [ ] **最终编译检查**
+
+```bash
+pnpm build
+```
+
+Expected: 构建成功，无 TypeScript/模板报错。
+
+- [ ] **全流程回归**
+
+浏览器依次验证：首页 discovery（行为不变）→ 侧边栏入口 → `/discovery` 三个 tab 切换、模式开关、换一批、无限滚动、关注操作。
+
+---
+
+## Self-Review 记录
+
+- **Spec 覆盖**：路由结构(Task 4/5/6)、独立 store(Task 2/3)、用户 API 适配(Task 1)、users 复用 FollowUserCard(Task 6)、R18 开关含 users 隐藏(Task 4)、侧边栏(Task 7)、文档(Task 8)、首页行为不变(Task 2 Step 4) —— 均有对应任务。
+- **类型一致性**：`buildDiscoveryUsers` / `DiscoveryUsersBody` / `getDiscoveryUsers` 在 Task 1 定义，Task 3 消费签名一致；store 导出的 `userDiscoveryList` 等命名在 Task 3 定义、Task 4/6 消费一致。
+- **Placeholder**：无 TBD/TODO；每个代码步骤均为完整代码。

--- a/docs/superpowers/plans/2026-06-23-discovery-page.md
+++ b/docs/superpowers/plans/2026-06-23-discovery-page.md
@@ -412,6 +412,8 @@ git commit -m "refactor(store): extract discovery store from home, keep home beh
 
 ### Task 3: discovery store 增加推荐用户
 
+> `fetchUserDiscovery` / `appendUserDiscovery` 用 `limit: 100`（接口硬上限，实测 101+ 报错）—— 一次拉满当缓冲，配合 Task 6 的增量渲染，并降低小批次整批撞车导致过早判定到底的概率。终止逻辑沿用「单批 0 新增即 `noMore`」。
+
 **Files:**
 - Modify: `app/stores/discovery.ts`
 
@@ -442,7 +444,7 @@ import type { ArtworkInfo, NovelInfo, UserListItem } from '~/types'
     if (loadingUserDiscovery.value) return
     try {
       loadingUserDiscovery.value = true
-      const users = await pixivClient.getDiscoveryUsers({ limit: 20 })
+      const users = await pixivClient.getDiscoveryUsers({ limit: 100 })
       userDiscoverySeenIds.clear()
       noMoreUserDiscovery.value = false
       users.forEach((u) => userDiscoverySeenIds.add(u.userId))
@@ -863,29 +865,35 @@ git commit -m "feat(discovery): add artworks and novels sub-pages"
 
 - [ ] **Step 1: 创建 `app/pages/discovery/users.vue`**
 
+**关键策略（应对 FollowUserCard DOM 较重）：网络层一次拉满 `limit: 100` 入缓冲（Task 3），渲染层用 `visibleCount` 增量 `slice` 显示，首屏只渲染 ~10 张。未登录直接提示登录、不发请求（接口必须登录）。**
+
 ```vue
 <template lang="pug">
 #discovery-users
-  .user-list(v-if='discoveryStore.userDiscoveryList.length')
-    Card(v-for='u in discoveryStore.userDiscoveryList', :key='u.userId')
-      FollowUserCard(:user='u')
-  .user-list(v-else-if='discoveryStore.loadingUserDiscovery')
-    Card(v-for='n in 4', :key='n')
-      FollowUserCard
-  .discover-footer(v-if='!discoveryStore.loadingUserDiscovery')
-    .loading-more(v-if='userStore.isLoggedIn && discoveryStore.loadingMoreUserDiscovery')
-      FnbSkeleton(block, height='2rem', width='200px')
-    .login-prompt(v-else-if='!userStore.isLoggedIn')
-      p 登录后查看推荐用户
-      FnbButton(
-        size='sm',
-        variant='primary',
-        tag='RouterLink',
-        to='/login?back=/discovery/users'
-      )
-        template(#icon): ITablerLogin
-        | 登录
-    div(v-else-if='userStore.isLoggedIn', ref='scrollSentinel')
+  //- endpoint requires auth — show login prompt directly, no request
+  .login-prompt(v-if='!userStore.isLoggedIn')
+    p 推荐用户需要登录后查看
+    FnbButton(
+      size='sm',
+      variant='primary',
+      tag='RouterLink',
+      to='/login?back=/discovery/users'
+    )
+      template(#icon): ITablerLogin
+      | 登录
+
+  template(v-else)
+    .user-list(v-if='visibleUsers.length')
+      Card(v-for='u in visibleUsers', :key='u.userId')
+        FollowUserCard(:user='u')
+    .user-list(v-else-if='discoveryStore.loadingUserDiscovery')
+      Card(v-for='n in 4', :key='n')
+        FollowUserCard
+
+    .discover-footer(v-if='!discoveryStore.loadingUserDiscovery && visibleUsers.length')
+      .loading-more(v-if='discoveryStore.loadingMoreUserDiscovery')
+        FnbSkeleton(block, height='2rem', width='200px')
+      div(v-else-if='!atEnd', ref='scrollSentinel')
 </template>
 
 <script lang="ts" setup>
@@ -897,11 +905,42 @@ const discoveryStore = useDiscoveryStore()
 const userStore = useUserStore()
 const scrollSentinel = ref<HTMLElement | null>(null)
 
-useIntersectionObserver(scrollSentinel, ([{ isIntersecting }]) => {
-  if (isIntersecting && userStore.isLoggedIn) {
+const PAGE_SIZE = 10
+const visibleCount = ref(PAGE_SIZE)
+
+const visibleUsers = computed(() =>
+  discoveryStore.userDiscoveryList.slice(0, visibleCount.value)
+)
+
+// buffer fully revealed AND store says nothing more to fetch
+const atEnd = computed(
+  () =>
+    visibleCount.value >= discoveryStore.userDiscoveryList.length &&
+    discoveryStore.noMoreUserDiscovery
+)
+
+function loadMore() {
+  const buffered = discoveryStore.userDiscoveryList.length
+  if (visibleCount.value < buffered) {
+    // reveal more from the already-fetched buffer (no request)
+    visibleCount.value = Math.min(visibleCount.value + PAGE_SIZE, buffered)
+  } else if (!discoveryStore.noMoreUserDiscovery) {
+    // buffer exhausted — fetch the next batch of 100
     discoveryStore.appendUserDiscovery()
   }
+}
+
+useIntersectionObserver(scrollSentinel, ([{ isIntersecting }]) => {
+  if (isIntersecting && userStore.isLoggedIn) loadMore()
 })
+
+// reset incremental reveal when the list is replaced by 换一批
+watch(
+  () => discoveryStore.userDiscoveryList.length,
+  (len, oldLen) => {
+    if (len < oldLen) visibleCount.value = PAGE_SIZE
+  }
+)
 
 function maybeFetch() {
   if (userStore.isLoggedIn && !discoveryStore.userDiscoveryList.length) {
@@ -929,15 +968,16 @@ onMounted(maybeFetch)
     display: flex;
     justify-content: center;
   }
+}
 
-  .login-prompt {
-    padding: 2rem;
-    color: var(--fnb-text-muted);
+.login-prompt {
+  padding: 2rem;
+  text-align: center;
+  color: var(--fnb-text-muted);
 
-    p {
-      margin-bottom: 0.75rem;
-      font-weight: 700;
-    }
+  p {
+    margin-bottom: 0.75rem;
+    font-weight: 700;
   }
 }
 </style>
@@ -945,14 +985,16 @@ onMounted(maybeFetch)
 
 - [ ] **Step 2: 验证（核心功能，需登录态）**
 
-确保浏览器已登录（有 PHPSESSID），打开 `http://localhost:3000/discovery/users`。
+① 未登录：打开 `http://localhost:3000/discovery/users`，应**直接显示「推荐用户需要登录后查看」+ 登录按钮**，且 Network 面板**无** `/ajax/discovery/users` 请求。
+
+② 已登录（浏览器有 PHPSESSID）：
 
 Expected:
-- 渲染推荐用户卡片列表（头像 / 用户名 / 自述 / 4 张作品预览）
-- 关注/取关按钮可点击且状态切换
-- 滚到底自动「换一批」追加（按 userId 去重）
+- 首屏只渲染约 10 张用户卡片（头像 / 用户名 / 自述 / 4 张作品预览），不卡顿
+- 向下滚动从缓冲增量显示更多（前若干次不发新请求）
+- 缓冲（100 个）显示完后滚动触发一次新的 `getDiscoveryUsers`（Network 可见），按 `userId` 去重追加
+- 关注 / 取关按钮可点击且状态切换
 - 顶部无 R18 下拉
-- 未登录时显示「登录后查看推荐用户」提示
 - console 无报错
 
 - [ ] **Step 3: 提交**

--- a/docs/superpowers/specs/2026-06-23-discovery-page-design.md
+++ b/docs/superpowers/specs/2026-06-23-discovery-page-design.md
@@ -19,6 +19,8 @@
 2. **接口忽略 `mode` 参数**：实测 `mode=safe/all/r18` 返回的 R18 占比仅随机波动，无过滤效果。用户推荐只跟随账号自身 R18 设置 → users 子页无法提供有效的 R18 开关。
 3. **无分页**：无 `offset` / `total`，每次返回随机一批。复用首页现有「seenIds 去重 + 追加」模式做无限滚动。
 4. artworks/novels 的 discovery 接口**支持** `mode`（现有 `getDiscovery` / `getNovelDiscovery` 已用 all/safe/r18）。
+5. **`limit` 硬上限 = 100**：实测 `limit=101` 起返回 `error: 不正确的请求`、`body` 为空数组；`limit<=100` 正常。
+6. **必须登录**：无 `PHPSESSID` 请求返回 `error: 不正确的请求`（推荐为个性化结果，合理）。未登录用户访问 users 子页直接提示登录，不发请求。
 
 ## 架构设计
 
@@ -70,10 +72,13 @@ app/pages/discovery/users.vue    推荐用户子页
 
 ### 4. users 子页（`discovery/users.vue`）
 
-- 渲染列表：复用 `FollowUserCard`（接收 `UserListItem`）+ `Card` 包裹 + `ShowMore`/无限滚动。
+- 渲染列表：复用 `FollowUserCard`（接收 `UserListItem`）+ `Card` 包裹。
 - 关注 / 取关：复用现有 `user-profile` store 的 `followUser` / `unfollowUser`（`FollowUserCard` 内部已实现）。
-- 无限滚动：滚到底自动 `appendUserDiscovery`，用 `userDiscoverySeenIds` 按 `userId` 去重；连续无新增时置 `noMoreUserDiscovery`。
-- 未登录态参照现有 discovery 的登录提示处理。
+- **大缓冲 + 增量渲染**（FollowUserCard DOM 较重，一次渲染 100 个会卡）：
+  - 网络层：`getDiscoveryUsers({ limit: 100 })` 一次拉满，去重后入 `userDiscoveryList` 缓冲。
+  - 渲染层：页面用 `visibleCount`（初始 ~10）`slice` 增量显示；sentinel 进入视口时，缓冲还有未显示的就 `visibleCount += 10`（纯客户端不发请求），缓冲耗尽且未到底才 `appendUserDiscovery()` 再拉 100 入缓冲；「换一批」重置缓冲 + `visibleCount`。
+  - 去重终止：与 artworks/novels 一致的「单批 0 新增即 `noMoreUserDiscovery`」。因每批拉 100、整批撞车概率极低，无需额外重试容错。
+- **未登录**：接口必须登录，未登录直接显示「请登录」提示，不发请求。
 
 ### 5. R18 开关
 

--- a/docs/superpowers/specs/2026-06-23-discovery-page-design.md
+++ b/docs/superpowers/specs/2026-06-23-discovery-page-design.md
@@ -78,6 +78,7 @@ app/pages/discovery/users.vue    推荐用户子页
   - 网络层：`getDiscoveryUsers({ limit: 100 })` 一次拉满，去重后入 `userDiscoveryList` 缓冲。
   - 渲染层：页面用 `visibleCount`（初始 ~10）`slice` 增量显示；sentinel 进入视口时，缓冲还有未显示的就 `visibleCount += 10`（纯客户端不发请求），缓冲耗尽且未到底才 `appendUserDiscovery()` 再拉 100 入缓冲；「换一批」重置缓冲 + `visibleCount`。
   - 去重终止：与 artworks/novels 一致的「单批 0 新增即 `noMoreUserDiscovery`」。因每批拉 100、整批撞车概率极低，无需额外重试容错。
+  - 屏外卡片用 CSS `content-visibility: auto` + `contain-intrinsic-size` 跳过渲染/图片解码（仅 users 卡片，几乎零成本，缓解长滚动卡顿）。不做真·虚拟滚动（YAGNI，且会与 `ArtworkList` 瀑布流冲突）。
 - **未登录**：接口必须登录，未登录直接显示「请登录」提示，不发请求。
 
 ### 5. R18 开关

--- a/docs/superpowers/specs/2026-06-23-discovery-page-design.md
+++ b/docs/superpowers/specs/2026-06-23-discovery-page-design.md
@@ -1,0 +1,109 @@
+# 统一探索发现页 `/discovery` 设计文档
+
+日期：2026-06-23
+
+## 背景与目标
+
+侧边栏预留了「探索发现」入口（目前 disabled）。当前 artworks/novels 的 discovery 逻辑散落在首页 `index.vue` + `home.ts` store 中。本次将其整合为独立的 `/discovery` 页面，并新增「推荐用户」子页面。
+
+最终形态：一个 `/discovery` 父页面，顶部 tab 切换三个子路由（artworks / novels / users），右侧一个 R18 模式开关。布局风格参照 following。
+
+## 关键接口验证结论
+
+以下结论均通过 `DEBUG_PIXIV_PHPSESSID` 实际请求 `/ajax/discovery/users?limit=20&lang=zh` 验证，非推测：
+
+1. **返回为关系型三段式结构**，需 join：
+   - `body.recommendedUsers[]`：`{ userId, recentIllustIds[], recentNovelIds[] }` —— 推荐顺序 + 每个用户展示哪些作品
+   - `body.users[]`：用户详情，字段命名为 `name` / `image` / `imageBig` / `comment` / `isFollowed` / `followedBack` / `isMypixiv` / `isBlocking` / `premium` / `commission`（即 `User` 风格，**非** `UserListItem` 的 `userName` / `profileImageUrl` 等）
+   - `body.thumbnails.illust[]`：标准 `ArtworkInfo` 形状的作品缩略图，靠 `recentIllustIds` 关联
+2. **接口忽略 `mode` 参数**：实测 `mode=safe/all/r18` 返回的 R18 占比仅随机波动，无过滤效果。用户推荐只跟随账号自身 R18 设置 → users 子页无法提供有效的 R18 开关。
+3. **无分页**：无 `offset` / `total`，每次返回随机一批。复用首页现有「seenIds 去重 + 追加」模式做无限滚动。
+4. artworks/novels 的 discovery 接口**支持** `mode`（现有 `getDiscovery` / `getNovelDiscovery` 已用 all/safe/r18）。
+
+## 架构设计
+
+### 1. 路由结构（Nuxt 嵌套路由）
+
+```
+app/pages/discovery.vue          父布局：标题 + 顶部 tab + R18 开关 + 换一批按钮 + <NuxtPage/>
+app/pages/discovery/artworks.vue 插画·漫画子页
+app/pages/discovery/novels.vue   小说子页
+app/pages/discovery/users.vue    推荐用户子页
+```
+
+- `/discovery` 重定向到 `/discovery/artworks`（在父布局或 `discovery/index.vue` 中 `navigateTo`）。
+- 顶部 tab 使用 **router-link** 切换子路由（高亮当前激活路由），而非 in-page panel。
+- 父布局持有共享控件（R18 开关、换一批）；切换 mode 或点换一批时，父布局依据当前路由调用对应子页 store 的 `fetch*`。
+
+### 2. 独立 `discovery` store（`app/stores/discovery.ts`）
+
+从 `home.ts` 抽离**纯 discovery 相关**的 state/actions：
+
+- 迁出：`discoveryList`、`novelDiscoveryList` 及各自的 `loading*` / `seenIds` / `noMore*` 标志、`discoveryMode`、`fetchDiscovery` / `appendDiscovery` / `fetchNovelDiscovery` / `appendNovelDiscovery`
+- **保留在 `home.ts`**：`randomBg` / `fetchRandomBg`（hero 背景，虽调用 `getDiscovery` 但与发现列表无关）、`rankingList` / `fetchRanking`、`followingList` / `fetchFollowing`
+- 新增 users 部分：`userDiscoveryList` / `loadingUserDiscovery` / `loadingMoreUserDiscovery` / `noMoreUserDiscovery` / `userDiscoverySeenIds` + `fetchUserDiscovery` / `appendUserDiscovery`（结构对齐现有 artworks/novels 的 fetch/append）
+
+**约束：首页 `index.vue` 行为完全不变。** 仅将其 discovery 数据源从 `home.ts` 改为引用新 `discovery` store，所有现有交互（tab 切换、mode 切换、换一批、无限滚动、URL query 同步、localStorage 记忆）保持原样。
+
+### 3. 推荐用户 API 适配层（`pixiv-client.ts`）
+
+新增 `getDiscoveryUsers({ limit })`，**在 client 内部完成三段 join**，返回干净的 `UserListItem[]`，使 store 与组件零改动复用 following 那套。
+
+字段映射：
+
+| `UserListItem` 字段 | `discovery/users` 来源 |
+| --- | --- |
+| `userId` | `users[].userId` |
+| `userName` | `users[].name` |
+| `profileImageUrl` | `users[].image` |
+| `userComment` | `users[].comment` |
+| `following` | `users[].isFollowed` |
+| `followed` | `users[].followedBack` |
+| `isMypixiv` | `users[].isMypixiv` |
+| `isBlocking` | `users[].isBlocking` |
+| `acceptRequest` | `users[].commission?.acceptRequest` |
+| `illusts` | `recommendedUsers[].recentIllustIds` join `thumbnails.illust`（按 id 匹配，保持顺序） |
+| `novels` | `recommendedUsers[].recentNovelIds` join `thumbnails.novel`（若存在，否则 `[]`） |
+
+- 顺序以 `recommendedUsers[]` 为准，按 `userId` 关联 `users[]` 详情。
+- `thumbnails.illust` 的形状与现有 `getDiscovery` 处理的一致，沿用同样的取字段方式构造 `ArtworkInfo`。
+
+### 4. users 子页（`discovery/users.vue`）
+
+- 渲染列表：复用 `FollowUserCard`（接收 `UserListItem`）+ `Card` 包裹 + `ShowMore`/无限滚动。
+- 关注 / 取关：复用现有 `user-profile` store 的 `followUser` / `unfollowUser`（`FollowUserCard` 内部已实现）。
+- 无限滚动：滚到底自动 `appendUserDiscovery`，用 `userDiscoverySeenIds` 按 `userId` 去重；连续无新增时置 `noMoreUserDiscovery`。
+- 未登录态参照现有 discovery 的登录提示处理。
+
+### 5. R18 开关
+
+- 父布局 `FnbSelect`，选项复用首页 `discoveryModeOptions`（混池 / 全年龄 / R18）。
+- artworks/novels 子页：映射到 store 的 `discoveryMode` → `mode` 参数。
+- **users 子页：隐藏开关**（接口忽略 mode，诚实地不展示）。
+
+### 6. 侧边栏（`SideNav.vue`）
+
+将禁用的「探索发现」项改为 `link='/discovery'`，去掉 `not-allowed` 占位。
+
+### 7. 文档（`docs/pixiv-web-api.md`）
+
+按既有格式新增 `/ajax/discovery/users` 接口章节：endpoint、参数表、`jsonc` 响应示例（含三段式结构说明）。
+
+## 复用一览
+
+| 复用项 | 来源 |
+| --- | --- |
+| 用户卡片 | `FollowUserCard.vue` + `Card.vue` |
+| 加载更多 | `ShowMore.vue` + `useIntersectionObserver` |
+| tab 栏 | 参照 following / 排行榜布局（router-link tab） |
+| R18 开关 | `FnbSelect` + `discoveryModeOptions` |
+| 作品 / 小说列表 | `ArtworkList.vue` / `NovelList.vue` |
+| 关注操作 | `user-profile` store |
+| artworks/novels 发现逻辑 | 从 `home.ts` 抽出的 fetch/append actions |
+
+## 不做的事（YAGNI）
+
+- 不为 users 子页实现客户端 R18 过滤（直接隐藏开关）。
+- 不改动首页 discovery 的任何可见行为，仅换数据源。
+- 不引入新的通用 toggle/switch 组件（项目无此组件，沿用 `FnbSelect`）。
+- 不处理 `recommendByTag` / `requests` / `illustSeries` 等返回中的额外字段。


### PR DESCRIPTION
## 概述

新增统一的 `/discovery` 探索发现页：顶部 tab 切换三个子路由（插画·漫画 / 小说 / 用户），右侧 R18 模式开关。同时把原本散落在首页 `home` store 的 discovery 逻辑抽成独立 `discovery` store，并接入侧边栏。

## 主要改动

- **API 适配层**（`app/api/discovery-users.ts` + `pixiv-client.ts`）：`getDiscoveryUsers()` 将 `/ajax/discovery/users` 的关系型三段式返回（`recommendedUsers` / `users` / `thumbnails`）join 成扁平的 `UserListItem[]`，从而零改动复用现有 `FollowUserCard`。
- **独立 `discovery` store**：从 `home.ts` 抽出 artworks/novels 的发现逻辑（**首页行为完全不变**，仅换数据源），并新增推荐用户的 state/actions。
- **路由**：`app/pages/discovery.vue` 父布局（router-link tab + R18 `FnbSelect` + 换一批）+ `discovery/{artworks,novels,users}.vue` 三个子页，`/discovery` 重定向到 `/discovery/artworks`。
- **users 子页性能策略**：大缓冲（一次拉满 `limit=100`）+ 增量渲染（`visibleCount` 滚动揭示，缓冲耗尽才发请求）+ 屏外卡片 `content-visibility: auto`，避免重 DOM 卡顿。
- **侧边栏**：新增与「导航」「用户」平级的「探索发现」分组，下挂三个入口。
- **文档**：`docs/pixiv-web-api.md` 补充 `/ajax/discovery/users` 接口章节。

## 接口验证结论（实测，非推测）

- `discovery/users` **必须登录**、**忽略 `mode` 参数**（故 users 子页不提供 R18 开关）、**`limit` 硬上限 100**、**无分页**（客户端按 id/userId 去重）。
- 未登录访问 users 子页直接提示登录，不发请求。

## 测试

- 项目无单测框架。join 纯函数用 node 对真实返回做了断言测试（`PASS users=20 ... illusts=N`）。
- 每个任务均通过 `pnpm build` 编译/类型/Pug 模板门禁；最终 HEAD 整体 build 通过。
- ⚠️ 浏览器真实交互尚未跑过，建议合并后做一次冒烟（三个子页 + users 登录态）。

## 不在本 PR 范围

- 退出登录确认框取消后 UI 仍登出的 bug（`SiteHeader.vue` + `userData.ts`，与本功能无关）将单独开分支修复。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

引入统一的 `/discovery` 页面，提供专门的路由、状态管理和 API 支持，用于作品、小说和推荐用户，并将现有的发现逻辑从首页 store 中重构出来，同时不改变首页的行为。

新功能：
- 添加 `/discovery` 路由，并为作品、小说和用户提供带标签页的子页面，包括带模式选择和刷新控件的共享页头。
- 实现基于 `/ajax/discovery/users` API 的推荐用户发现体验，并通过现有的用户关注卡片进行渲染。
- 在侧边导航中暴露发现入口，提供直接访问新发现页面的能力。

增强：
- 将与发现相关的状态和逻辑提取到独立的 Pinia `discovery` store 中，使首页 store 专注于背景、排行和关注数据。
- 通过批量获取和增量渲染优化用户发现页面，以减少滚动时的 DOM 负载。
- 为 `/ajax/discovery/users` 端点编写文档，并记录统一发现页面的设计和实现方案。

文档：
- 在 `docs/pixiv-web-api.md` 中记录 `/ajax/discovery/users` Pixiv Web API 的响应结构和使用方式。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a unified `/discovery` page with dedicated routing, state management, and API support for artworks, novels, and recommended users, while refactoring existing discovery logic out of the home store without changing homepage behavior.

New Features:
- Add a `/discovery` route with tabbed sub-pages for artworks, novels, and users, including a shared header with mode selection and refresh controls.
- Implement a recommended users discovery experience backed by the `/ajax/discovery/users` API and rendering via existing user follow cards.
- Expose discovery entries in the side navigation, providing direct access to the new discovery pages.

Enhancements:
- Extract discovery-related state and logic into a dedicated Pinia `discovery` store, keeping the home store focused on background, ranking, and following data.
- Optimize the users discovery page with batched fetching and incremental rendering to reduce DOM load during scrolling.
- Document the `/ajax/discovery/users` endpoint and record the design and implementation plan for the unified discovery page.

Documentation:
- Document the `/ajax/discovery/users` Pixiv web API response shape and usage in `docs/pixiv-web-api.md`.

</details>