### PR TITLE
feat: query-based search routes with /search landing page and header scope selector

### DIFF
--- a/app/components/ArtTag.vue
+++ b/app/components/ArtTag.vue
@@ -12,10 +12,8 @@ const props = defineProps<{
 }>()
 
 const searchUrl = computed(() => {
-  const base = `/search/${encodeURIComponent(props.tag)}/1`
-  if (!props.searchQuery || !Object.keys(props.searchQuery).length) return base
-  const qs = new URLSearchParams(props.searchQuery).toString()
-  return `${base}?${qs}`
+  const params = new URLSearchParams({ q: props.tag, ...(props.searchQuery ?? {}) })
+  return `/search?${params.toString()}`
 })
 </script>
 

--- a/app/components/SearchBox.vue
+++ b/app/components/SearchBox.vue
@@ -12,7 +12,7 @@
 import IFasSearch from '~icons/fa-solid/search'
 const route = useRoute()
 const router = useRouter()
-const keyword = ref((route.params.keyword as string) || '')
+const keyword = ref((route.query.q as string) || '')
 
 function makeSearch(): void {
   if (!keyword.value) {
@@ -22,7 +22,7 @@ function makeSearch(): void {
     router.push(`/artworks/${/^id:(\d+)$/.exec(keyword.value)?.[1]}`)
     return
   }
-  router.push(`/search/${encodeURIComponent(keyword.value)}/1`)
+  router.push({ path: '/search', query: { q: keyword.value } })
 }
 </script>
 

--- a/app/components/SearchBox.vue
+++ b/app/components/SearchBox.vue
@@ -1,15 +1,21 @@
 <template lang="pug">
-.search-box
+.search-box(:class='{ "no-icon": noIcon }')
   input(
     @keyup.enter='makeSearch'
     placeholder='输入关键词搜索/输入 id:数字 查看作品'
     v-model='keyword'
   )
-  IFasSearch.icon(data-icon)
+  IFasSearch.icon(data-icon, v-if='!noIcon')
 </template>
 
 <script lang="ts" setup>
 import IFasSearch from '~icons/fa-solid/search'
+
+const props = defineProps<{
+  type?: string
+  noIcon?: boolean
+}>()
+
 const route = useRoute()
 const router = useRouter()
 const keyword = ref((route.query.q as string) || '')
@@ -22,7 +28,11 @@ function makeSearch(): void {
     router.push(`/artworks/${/^id:(\d+)$/.exec(keyword.value)?.[1]}`)
     return
   }
-  router.push({ path: '/search', query: { q: keyword.value } })
+  const query: Record<string, string> = { q: keyword.value }
+  if (props.type && props.type !== 'artworks') {
+    query.type = props.type
+  }
+  router.push({ path: '/search', query })
 }
 </script>
 
@@ -34,6 +44,10 @@ function makeSearch(): void {
   position: relative;
   align-items: center;
   font-size: 0.8rem;
+
+  &.no-icon input {
+    padding-left: 0.6em;
+  }
 
   .icon,
   [data-icon] {

--- a/app/components/SideNav/SideNav.vue
+++ b/app/components/SideNav/SideNav.vue
@@ -14,6 +14,8 @@ aside.global-side-nav(:class='{ hidden: !sideNavStore.isOpened }')
             IFasHome.link-icon
           SideNavListLink(link='/ranking' text='排行榜')
             IFasCrown.link-icon
+          SideNavListLink(link='/search' text='搜索')
+            IFasSearch.link-icon
 
       .group
         .title 探索发现
@@ -65,6 +67,7 @@ import IFasHeart from '~icons/fa-solid/heart'
 import IFasHome from '~icons/fa-solid/home'
 import IFasBook from '~icons/fa-solid/book'
 import IFasImage from '~icons/fa-solid/image'
+import IFasSearch from '~icons/fa-solid/search'
 import IFasUser from '~icons/fa-solid/user'
 import { useSideNavStore, useUserStore } from '~/stores/session'
 

--- a/app/components/SiteHeader.vue
+++ b/app/components/SiteHeader.vue
@@ -15,7 +15,14 @@ header.global-navbar(:class='{ "not-at-top": notAtTop, hidden, "side-nav-opened"
 
     .flex.search-area(v-if='$route.name !== "search"')
       .search-full.align-right.flex-1
-        SearchBox
+        .header-search
+          FnbSelect.search-scope(
+            v-if='wide',
+            :model-value='searchType',
+            :options='contentOptions',
+            @update:model-value='searchType = $event'
+          )
+          SearchBox(:type='effectiveType', :no-icon='wide')
       .search-icon.align-right.flex-1
         button.pointer.plain(
           aria-label='搜索'
@@ -85,6 +92,7 @@ header.global-navbar(:class='{ "not-at-top": notAtTop, hidden, "side-nav-opened"
 
 <script lang="ts" setup>
 import SearchBox from './SearchBox.vue'
+import { contentOptions } from '~/utils/searchOptions'
 import IFasBars from '~icons/fa-solid/bars'
 import IFasSearch from '~icons/fa-solid/search'
 import { logout } from '~/composables/userData'
@@ -100,6 +108,10 @@ const showUserDropdown = ref(false)
 const userLinkRef = ref<HTMLElement | null>(null)
 const sideNavStore = useSideNavStore()
 const userStore = useUserStore()
+
+const searchType = ref('artworks')
+const wide = useMediaQuery('(min-width: 768px)')
+const effectiveType = computed(() => (wide.value ? searchType.value : 'artworks'))
 
 // Close dropdown when clicking outside .user-link
 onClickOutside(userLinkRef, () => {
@@ -204,6 +216,51 @@ useEventListener(window, 'scroll', () => {
 
   .search-area {
     flex: 1;
+  }
+
+  // Scope selector + search input merged into one pill
+  .header-search {
+    display: flex;
+    align-items: stretch;
+    width: 100%;
+    background: var(--fnb-surface);
+    @include fnb-border-sm;
+    @include fnb-shadow-sm;
+    border-radius: var(--fnb-radius-sm);
+    // header sets color:#fff and .align-right — reset inside the pill
+    color: var(--fnb-text);
+    text-align: left;
+
+    .search-scope {
+      min-width: auto;
+      flex-shrink: 0;
+    }
+
+    .fnb-select-trigger {
+      border: none;
+      box-shadow: none;
+      border-right: 2px solid var(--fnb-border);
+      border-radius: var(--fnb-radius-sm) 0 0 var(--fnb-radius-sm);
+      background: transparent;
+      height: 100%;
+
+      &:hover {
+        transform: none;
+        background: var(--fnb-highlight);
+      }
+    }
+
+    .search-box {
+      flex: 1;
+
+      input {
+        border: none;
+        box-shadow: none;
+        background: transparent;
+        color: var(--fnb-text);
+        text-align: left;
+      }
+    }
   }
 
   .user-area {

--- a/app/middleware/route-aliases.global.ts
+++ b/app/middleware/route-aliases.global.ts
@@ -1,7 +1,25 @@
 export default defineNuxtRouteMiddleware((to) => {
-  // /search/:keyword → /search/:keyword/1
-  const searchMatch = to.path.match(/^\/search\/([^/]+)$/)
-  if (searchMatch) {
-    return navigateTo(`/search/${searchMatch[1]}/1`, { redirectCode: 302 })
+  // Legacy search URLs → new query-based /search
+  //   /search/:keyword            → /search?q=:keyword
+  //   /search/:keyword/:page      → /search?q=:keyword&p=:page
+  // Old `content` query param is renamed to `type`; other filter params pass through.
+  const m = to.path.match(/^\/search\/([^/]+)(?:\/([^/]+))?\/?$/)
+  if (m) {
+    const keyword = decodeURIComponent(m[1])
+    const page = m[2]
+    const query: Record<string, string> = {
+      ...(to.query as Record<string, string>),
+    }
+    if (query.content) {
+      query.type = query.content
+      delete query.content
+    }
+    query.q = keyword
+    if (page && page !== '1') {
+      query.p = page
+    } else {
+      delete query.p
+    }
+    return navigateTo({ path: '/search', query }, { redirectCode: 302 })
   }
 })

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -59,7 +59,7 @@
               FnbTag(
                 :key='tag',
                 clickable,
-                @click='$router.push(`/search/${encodeURIComponent(tag)}/1`)',
+                @click='$router.push({ path: "/search", query: { q: tag } })',
                 v-for='tag in randomBg?.tags'
               ) {{ tag }}
 

--- a/app/pages/novel/series/[id].vue
+++ b/app/pages/novel/series/[id].vue
@@ -29,7 +29,7 @@
             ArtTag(
               :key='tag',
               :tag='tag',
-              :search-query='{ content: "novels", s_mode: "s_tag_only" }',
+              :search-query='{ type: "novels", s_mode: "s_tag_only" }',
               v-for='tag in series.tags'
             )
           .actions

--- a/app/pages/novels/[id].vue
+++ b/app/pages/novels/[id].vue
@@ -56,7 +56,7 @@
             ArtTag(
               :key='tag.tag',
               :tag='tag.tag',
-              :search-query='{ content: "novels", s_mode: "s_tag_only" }',
+              :search-query='{ type: "novels", s_mode: "s_tag_only" }',
               v-for='tag in novel.tags.tags'
             )
 

--- a/app/pages/search.vue
+++ b/app/pages/search.vue
@@ -101,16 +101,9 @@ import SearchBox from '~/components/SearchBox.vue'
 import { useSearchStore, type SearchContentType } from '~/stores/search'
 import { effect } from 'vue'
 import { setTitle } from '~/utils/setTitle'
+import { contentOptions } from '~/utils/searchOptions'
 
 // ── Filter options ──
-
-const contentOptions = [
-  { label: '综合', value: 'artworks' },
-  { label: '插画', value: 'illustrations' },
-  { label: '动图', value: 'ugoira' },
-  { label: '漫画', value: 'manga' },
-  { label: '小说', value: 'novels' },
-]
 
 const artworkSModeOptions = [
   { label: '标签（部分一致）', value: 's_tag' },

--- a/app/pages/search.vue
+++ b/app/pages/search.vue
@@ -54,8 +54,7 @@
   //- Landing: no keyword yet
   section.search-landing(v-else-if='!hasQuery')
     .body-inner
-      FnbCard(style='padding: 12vh 0; text-align: center')
-        .fnb-empty 输入关键词开始搜索
+      .fnb-empty(style='padding: 12vh 0; text-align: center') 输入关键词开始搜索
 
   //- Result (has keyword)
   section(v-else)

--- a/app/pages/search.vue
+++ b/app/pages/search.vue
@@ -7,8 +7,8 @@
         button.content-tab(
           v-for='opt in contentOptions',
           :key='opt.value',
-          :class='{ active: selectedContent === opt.value }',
-          @click='setQuery({ content: opt.value })'
+          :class='{ active: selectedType === opt.value }',
+          @click='setQuery({ type: opt.value })'
         ) {{ opt.label }}
       .refine-bar
         .refine-field
@@ -51,8 +51,14 @@
   section(v-if='error && !searchStore.loading')
     ErrorPage(:description='error' title='出大问题')
 
-  //- Result
-  section(v-if='!error')
+  //- Landing: no keyword yet
+  section.search-landing(v-else-if='!hasQuery')
+    .body-inner
+      FnbCard(style='padding: 12vh 0; text-align: center')
+        .fnb-empty 输入关键词开始搜索
+
+  //- Result (has keyword)
+  section(v-else)
 
     //- Loading skeleton
     .loading-area(v-if='searchStore.loading && !currentResults.length')
@@ -73,7 +79,7 @@
             :page='page',
             :item-count='currentTotal',
             :page-size='currentResults.length',
-            @update:page='page = $event'
+            @update:page='goPage'
           )
         ArtworkLargeList(v-if='!isNovel', :artwork-list='searchStore.artworkResults')
         NovelList(v-else, :list='searchStore.novelResults')
@@ -82,7 +88,7 @@
             :page='page',
             :item-count='currentTotal',
             :page-size='currentResults.length',
-            @update:page='page = $event'
+            @update:page='goPage'
           )
 </template>
 
@@ -148,27 +154,25 @@ const langOptions = [
 // ── State ──
 
 const error = ref('')
-const searchKeyword = ref('')
-const page = ref(1)
 const route = useRoute()
 const router = useRouter()
 const searchStore = useSearchStore()
 
-const selectedContent = computed(
-  () => (route.query.content as string) || 'artworks'
-)
-const selectedSMode = computed(() => {
-  if (route.query.s_mode) return route.query.s_mode as string
-  return 's_tag'
+const keyword = computed(() => (route.query.q as string) || '')
+const hasQuery = computed(() => !!keyword.value)
+const page = computed(() => {
+  const p = parseInt((route.query.p as string) || '1')
+  return p > 0 ? p : 1
 })
-const selectedOrder = computed(
-  () => (route.query.order as string) || 'date_d'
-)
+
+const selectedType = computed(() => (route.query.type as string) || 'artworks')
+const selectedSMode = computed(() => (route.query.s_mode as string) || 's_tag')
+const selectedOrder = computed(() => (route.query.order as string) || 'date_d')
 const selectedMode = computed(() => (route.query.mode as string) || 'all')
 const selectedAiType = computed(() => (route.query.ai_type as string) || '')
 const selectedLang = computed(() => (route.query.lang as string) || '')
 
-const isNovel = computed(() => selectedContent.value === 'novels')
+const isNovel = computed(() => selectedType.value === 'novels')
 
 const activeSModeOptions = computed(() =>
   isNovel.value ? novelSModeOptions : artworkSModeOptions
@@ -185,7 +189,7 @@ const currentTotal = computed(() =>
 // ── Query helpers ──
 
 const defaults: Record<string, string> = {
-  content: 'artworks',
+  type: 'artworks',
   s_mode: 's_tag',
   order: 'date_d',
   mode: 'all',
@@ -195,7 +199,7 @@ const defaults: Record<string, string> = {
 
 function setQuery(updates: Record<string, string>) {
   const q = { ...route.query } as Record<string, string>
-  const isContentSwitch = 'content' in updates
+  const isTypeSwitch = 'type' in updates
 
   for (const [key, value] of Object.entries(updates)) {
     if (value === defaults[key] || value === '') {
@@ -205,7 +209,7 @@ function setQuery(updates: Record<string, string>) {
     }
   }
 
-  if (isContentSwitch) {
+  if (isTypeSwitch) {
     delete q.s_mode
     delete q.lang
   }
@@ -214,20 +218,24 @@ function setQuery(updates: Record<string, string>) {
   router.push({ query: q })
 }
 
+function goPage(value: number) {
+  const target = value < 1 ? 1 : value
+  const q = { ...route.query } as Record<string, string>
+  if (target === 1) delete q.p
+  else q.p = String(target)
+  router.push({ query: q })
+}
+
 // ── Search execution ──
 
 async function makeSearch(): Promise<void> {
-  const keyword = route.params.keyword as string
-  const p = parseInt((route.params.p as string) || '1')
-  searchKeyword.value = keyword
-  page.value = p
   error.value = ''
-  if (!keyword) return
+  if (!keyword.value) return
 
   try {
     if (isNovel.value) {
-      await searchStore.searchNovels(keyword, {
-        p,
+      await searchStore.searchNovels(keyword.value, {
+        p: page.value,
         s_mode: selectedSMode.value,
         order: selectedOrder.value,
         mode: selectedMode.value,
@@ -236,10 +244,10 @@ async function makeSearch(): Promise<void> {
       })
     } else {
       await searchStore.searchArtworks(
-        keyword,
-        selectedContent.value as SearchContentType,
+        keyword.value,
+        selectedType.value as SearchContentType,
         {
-          p,
+          p: page.value,
           s_mode: selectedSMode.value,
           order: selectedOrder.value,
           mode: selectedMode.value,
@@ -258,30 +266,12 @@ async function makeSearch(): Promise<void> {
 
 // ── Watchers ──
 
-watch(page, (value) => {
-  page.value = value < 1 ? 1 : value
-  const q = { ...route.query } as Record<string, string>
-  delete q.p
-  const qs = new URLSearchParams(q).toString()
-  router.push(
-    `/search/${searchKeyword.value}/${page.value}${qs ? `?${qs}` : ''}`
-  )
-})
-
 watch(() => route.query, makeSearch, { deep: true })
 
-onBeforeRouteUpdate(async (to) => {
-  if (
-    to.params.keyword !== route.params.keyword ||
-    to.params.p !== route.params.p
-  ) {
-    await nextTick()
-    makeSearch()
-  }
-})
-
 effect(() =>
-  setTitle(`${route.params.keyword} (第${route.params.p}页)`, 'Search')
+  keyword.value
+    ? setTitle(`${keyword.value} (第${page.value}页)`, 'Search')
+    : setTitle('搜索')
 )
 
 onMounted(() => makeSearch())

--- a/app/utils/searchOptions.ts
+++ b/app/utils/searchOptions.ts
@@ -1,0 +1,13 @@
+export interface SearchContentOption {
+  label: string
+  value: string
+}
+
+// Search content types — shared by the search page tabs and the header scope selector.
+export const contentOptions: SearchContentOption[] = [
+  { label: '综合', value: 'artworks' },
+  { label: '插画', value: 'illustrations' },
+  { label: '动图', value: 'ugoira' },
+  { label: '漫画', value: 'manga' },
+  { label: '小说', value: 'novels' },
+]

--- a/docs/superpowers/plans/2026-06-23-search-routes.md
+++ b/docs/superpowers/plans/2026-06-23-search-routes.md
@@ -1,0 +1,616 @@
+# 搜索路由重构 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 把搜索从 `/search/:keyword/:p` 改为全 query 方案 `/search?q=&type=&p=&...`，新增 `/search` 落地页，并对旧 URL 做 302 重定向兼容。
+
+**Architecture:** `git mv` 现有搜索页到 `app/pages/search.vue`，数据源从 path param 改为 query；改写 `route-aliases.global.ts` 把旧 URL 重定向到新方案；更新所有硬编码旧路由的内部链接。store 与 pixiv-client 不动。
+
+**Tech Stack:** Nuxt 4 / Vue 3 SFC（Pug + SCSS）/ vue-router / Pinia。
+
+## Global Constraints
+
+- 代码风格：无分号、单引号、2 空格缩进、es5 trailing comma。模板用 Pug，样式 SCSS。
+- 客户端 SPA（SSR 已禁用）。Vue/Nuxt composable、Pinia store、`components/` 组件自动导入；`~icons/*` 需显式 import。
+- **项目无测试框架**（CLAUDE.md 确认无 test/lint）。验证门禁 = `pnpm build`（编译 + Pug 模板通过）；可视化交互留最终人工浏览器冒烟。
+- query 参数名：`q`（关键词）、`type`（搜索方案，原 `content`）、`p`（页码）、`mode`/`s_mode`/`order`/`ai_type`/`lang`。沿用「默认值不写入 URL」清洁策略。
+- 搜索页 `definePageMeta({ name: 'search' })` 必须保留（`SiteHeader` 依赖 `$route.name !== 'search'`）。
+- 编写/修改 Pug 模板注意 pug-vue-pitfalls（属性逗号分隔、`:class` 对象语法、内联表达式引号）。
+- 不改 `app/stores/search.ts` 与 `pixiv-client` 搜索方法；不新增搜索类型；落地页不做热门标签/历史（YAGNI）。
+
+---
+
+### Task 1: 重命名并改造搜索页为全 query 方案
+
+`git mv` 旧动态路由文件到 `app/pages/search.vue`（保留 git 历史），整文件替换为 query 驱动版本：数据源 path→query、`content`→`type`、落地空态、翻页简化、watcher 简化。
+
+**Files:**
+- Rename: `app/pages/search/[keyword]/[p].vue` → `app/pages/search.vue`（`git mv`），随后删除空目录 `app/pages/search/`
+- 该文件整体覆盖为下方内容
+
+**Interfaces:**
+- Consumes: `useSearchStore()` 的 `searchArtworks(keyword, type, params)` / `searchNovels(keyword, params)` / `artworkResults` / `novelResults` / `artworkTotal` / `novelTotal` / `loading`（均已存在，不改）
+- Produces: 路由 `/search`（name `search`），消费 query keys `q`/`type`/`p`/`mode`/`s_mode`/`order`/`ai_type`/`lang`
+
+- [ ] **Step 1: `git mv` 重命名并删空目录**
+
+```bash
+cd /Users/xiaoyujun/GitRepositories/PixivNow
+git mv "app/pages/search/[keyword]/[p].vue" app/pages/search.vue
+rmdir "app/pages/search/[keyword]" "app/pages/search" 2>/dev/null || true
+```
+
+- [ ] **Step 2: 用 query 驱动版本整体覆盖 `app/pages/search.vue`**
+
+```vue
+<template lang="pug">
+#search-view
+  .body-inner
+    SearchBox.big
+    .search-filters
+      .content-tabs
+        button.content-tab(
+          v-for='opt in contentOptions',
+          :key='opt.value',
+          :class='{ active: selectedType === opt.value }',
+          @click='setQuery({ type: opt.value })'
+        ) {{ opt.label }}
+      .refine-bar
+        .refine-field
+          span.refine-label 匹配
+          FnbSelect(
+            :model-value='selectedSMode',
+            :options='activeSModeOptions',
+            @update:model-value='v => setQuery({ s_mode: v })'
+          )
+        .refine-field
+          span.refine-label 排序
+          FnbSelect(
+            :model-value='selectedOrder',
+            :options='orderOptions',
+            @update:model-value='v => setQuery({ order: v })'
+          )
+        .refine-field
+          span.refine-label 分级
+          FnbSelect(
+            :model-value='selectedMode',
+            :options='modeOptions',
+            @update:model-value='v => setQuery({ mode: v })'
+          )
+        .refine-field
+          span.refine-label AI
+          FnbSelect(
+            :model-value='selectedAiType',
+            :options='aiTypeOptions',
+            @update:model-value='v => setQuery({ ai_type: v })'
+          )
+        .refine-field(v-if='isNovel')
+          span.refine-label 语言
+          FnbSelect(
+            :model-value='selectedLang',
+            :options='langOptions',
+            @update:model-value='v => setQuery({ lang: v })'
+          )
+
+  //- Error
+  section(v-if='error && !searchStore.loading')
+    ErrorPage(:description='error' title='出大问题')
+
+  //- Landing: no keyword yet
+  section.search-landing(v-else-if='!hasQuery')
+    .body-inner
+      FnbCard(style='padding: 12vh 0; text-align: center')
+        .fnb-empty 输入关键词开始搜索
+
+  //- Result (has keyword)
+  section(v-else)
+
+    //- Loading skeleton
+    .loading-area(v-if='searchStore.loading && !currentResults.length')
+      ArtworkList(v-if='!isNovel', :list='[]', :loading='16')
+      .body-inner(v-else)
+        NovelList(:list='[]', :loading='12')
+
+    //- Empty
+    .no-more(v-if='!searchStore.loading && !currentResults.length')
+      FnbCard(style='padding: 15vh 0; text-align: center')
+        .fnb-empty 没有了，一滴都没有了……
+
+    //- Results
+    FnbSpin.result-area(:show='searchStore.loading', v-if='currentResults.length')
+      .body-inner
+        .pagenator
+          FnbPagination(
+            :page='page',
+            :item-count='currentTotal',
+            :page-size='currentResults.length',
+            @update:page='goPage'
+          )
+        ArtworkLargeList(v-if='!isNovel', :artwork-list='searchStore.artworkResults')
+        NovelList(v-else, :list='searchStore.novelResults')
+        .pagenator
+          FnbPagination(
+            :page='page',
+            :item-count='currentTotal',
+            :page-size='currentResults.length',
+            @update:page='goPage'
+          )
+</template>
+
+<script lang="ts" setup>
+definePageMeta({ name: 'search' })
+import ArtworkLargeList from '~/components/Artwork/ArtworkLargeList.vue'
+import ArtworkList from '~/components/Artwork/ArtworkList.vue'
+import NovelList from '~/components/Novel/NovelList.vue'
+import ErrorPage from '~/components/ErrorPage.vue'
+import SearchBox from '~/components/SearchBox.vue'
+import { useSearchStore, type SearchContentType } from '~/stores/search'
+import { effect } from 'vue'
+import { setTitle } from '~/utils/setTitle'
+
+// ── Filter options ──
+
+const contentOptions = [
+  { label: '综合', value: 'artworks' },
+  { label: '插画', value: 'illustrations' },
+  { label: '动图', value: 'ugoira' },
+  { label: '漫画', value: 'manga' },
+  { label: '小说', value: 'novels' },
+]
+
+const artworkSModeOptions = [
+  { label: '标签（部分一致）', value: 's_tag' },
+  { label: '标签（完全一致）', value: 's_tag_full' },
+  { label: '标题、说明文字', value: 's_tc' },
+  { label: '标签、标题、说明', value: 's_tag_tc' },
+]
+
+const novelSModeOptions = [
+  { label: '标签、标题、说明', value: 's_tag' },
+  { label: '标签（部分一致）', value: 's_tag_only' },
+  { label: '标签（完全一致）', value: 's_tag_full' },
+  { label: '正文', value: 's_tc' },
+]
+
+const orderOptions = [
+  { label: '新到旧', value: 'date_d' },
+  { label: '旧到新', value: 'date' },
+]
+
+const modeOptions = [
+  { label: '混池', value: 'all' },
+  { label: '全年龄', value: 'safe' },
+  { label: 'R18', value: 'r18' },
+]
+
+const aiTypeOptions = [
+  { label: '含AI作品', value: '' },
+  { label: '隐藏AI作品', value: '1' },
+]
+
+const langOptions = [
+  { label: '全部语言', value: '' },
+  { label: '中文', value: 'zh-cn' },
+  { label: '日本語', value: 'ja' },
+  { label: 'English', value: 'en' },
+  { label: '한국어', value: 'ko' },
+]
+
+// ── State ──
+
+const error = ref('')
+const route = useRoute()
+const router = useRouter()
+const searchStore = useSearchStore()
+
+const keyword = computed(() => (route.query.q as string) || '')
+const hasQuery = computed(() => !!keyword.value)
+const page = computed(() => {
+  const p = parseInt((route.query.p as string) || '1')
+  return p > 0 ? p : 1
+})
+
+const selectedType = computed(() => (route.query.type as string) || 'artworks')
+const selectedSMode = computed(() => (route.query.s_mode as string) || 's_tag')
+const selectedOrder = computed(() => (route.query.order as string) || 'date_d')
+const selectedMode = computed(() => (route.query.mode as string) || 'all')
+const selectedAiType = computed(() => (route.query.ai_type as string) || '')
+const selectedLang = computed(() => (route.query.lang as string) || '')
+
+const isNovel = computed(() => selectedType.value === 'novels')
+
+const activeSModeOptions = computed(() =>
+  isNovel.value ? novelSModeOptions : artworkSModeOptions
+)
+
+const currentResults = computed(() =>
+  isNovel.value ? searchStore.novelResults : searchStore.artworkResults
+)
+
+const currentTotal = computed(() =>
+  isNovel.value ? searchStore.novelTotal : searchStore.artworkTotal
+)
+
+// ── Query helpers ──
+
+const defaults: Record<string, string> = {
+  type: 'artworks',
+  s_mode: 's_tag',
+  order: 'date_d',
+  mode: 'all',
+  ai_type: '',
+  lang: '',
+}
+
+function setQuery(updates: Record<string, string>) {
+  const q = { ...route.query } as Record<string, string>
+  const isTypeSwitch = 'type' in updates
+
+  for (const [key, value] of Object.entries(updates)) {
+    if (value === defaults[key] || value === '') {
+      delete q[key]
+    } else {
+      q[key] = value
+    }
+  }
+
+  if (isTypeSwitch) {
+    delete q.s_mode
+    delete q.lang
+  }
+
+  delete q.p
+  router.push({ query: q })
+}
+
+function goPage(value: number) {
+  const target = value < 1 ? 1 : value
+  const q = { ...route.query } as Record<string, string>
+  if (target === 1) delete q.p
+  else q.p = String(target)
+  router.push({ query: q })
+}
+
+// ── Search execution ──
+
+async function makeSearch(): Promise<void> {
+  error.value = ''
+  if (!keyword.value) return
+
+  try {
+    if (isNovel.value) {
+      await searchStore.searchNovels(keyword.value, {
+        p: page.value,
+        s_mode: selectedSMode.value,
+        order: selectedOrder.value,
+        mode: selectedMode.value,
+        ai_type: selectedAiType.value || undefined,
+        work_lang: selectedLang.value || undefined,
+      })
+    } else {
+      await searchStore.searchArtworks(
+        keyword.value,
+        selectedType.value as SearchContentType,
+        {
+          p: page.value,
+          s_mode: selectedSMode.value,
+          order: selectedOrder.value,
+          mode: selectedMode.value,
+          ai_type: selectedAiType.value || undefined,
+        }
+      )
+    }
+  } catch (err) {
+    if (err instanceof Error) {
+      error.value = err.message
+    } else {
+      error.value = '哎呀，出错了！'
+    }
+  }
+}
+
+// ── Watchers ──
+
+watch(() => route.query, makeSearch, { deep: true })
+
+effect(() =>
+  keyword.value
+    ? setTitle(`${keyword.value} (第${page.value}页)`, 'Search')
+    : setTitle('搜索')
+)
+
+onMounted(() => makeSearch())
+</script>
+
+<style lang="scss" scoped>
+.search-filters {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  margin-top: 1rem;
+}
+
+// ── Primary axis: content type ──
+.content-tabs {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.content-tab {
+  @include fnb-border-sm;
+  @include fnb-shadow-xs;
+  padding: 0.4rem 0.95rem;
+  font-family: var(--fnb-font-display);
+  font-size: 0.9rem;
+  font-weight: 800;
+  background: var(--fnb-surface);
+  color: var(--fnb-text);
+  cursor: pointer;
+  transition: all 150ms;
+
+  &.active {
+    background: var(--fnb-brand);
+    color: #fff;
+    box-shadow: none;
+    transform: translate(2px, 2px);
+  }
+
+  &:hover:not(.active) {
+    background: var(--fnb-highlight);
+  }
+}
+
+// ── Secondary axis: refinement ──
+.refine-bar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.55rem 1.15rem;
+}
+
+.refine-field {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+}
+
+.refine-label {
+  font-size: 0.75rem;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  color: var(--fnb-text-muted);
+  white-space: nowrap;
+}
+
+.pagenator {
+  display: flex;
+  justify-content: center;
+  margin: 1rem auto;
+}
+
+.no-more {
+  text-align: center;
+  padding: 1rem;
+  opacity: 0.75;
+}
+
+.search-box {
+  margin: 1rem auto;
+  margin-top: 2rem;
+  box-shadow: 0 0 8px #ddd;
+}
+
+.fnb-empty {
+  color: var(--fnb-text-muted);
+  padding: 1rem;
+}
+</style>
+```
+
+- [ ] **Step 3: 构建验证**
+
+Run: `pnpm build`
+Expected: `✨ Build complete!`，无 TypeScript/Pug/编译错误。
+
+- [ ] **Step 4: 确认旧目录已删除**
+
+Run: `ls app/pages/search.vue && ! test -d "app/pages/search" && echo "OK: file moved, dir removed"`
+Expected: 打印 `OK: file moved, dir removed`。
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add -A
+git commit -m "refactor(search): migrate search page to query-based /search route"
+```
+
+---
+
+### Task 2: 旧 URL 302 重定向兼容
+
+改写 `app/middleware/route-aliases.global.ts`，把旧 `/search/:keyword` 与 `/search/:keyword/:page`（连同原 query）重定向到新 `/search?q=...`。
+
+**Files:**
+- Modify: `app/middleware/route-aliases.global.ts`（整体替换）
+
+**Interfaces:**
+- Consumes: 新路由 `/search`（Task 1）与其 query 模型
+- Produces: 无（纯重定向中间件）
+
+- [ ] **Step 1: 整体替换 `app/middleware/route-aliases.global.ts`**
+
+```ts
+export default defineNuxtRouteMiddleware((to) => {
+  // Legacy search URLs → new query-based /search
+  //   /search/:keyword            → /search?q=:keyword
+  //   /search/:keyword/:page      → /search?q=:keyword&p=:page
+  // Old `content` query param is renamed to `type`; other filter params pass through.
+  const m = to.path.match(/^\/search\/([^/]+)(?:\/([^/]+))?\/?$/)
+  if (m) {
+    const keyword = decodeURIComponent(m[1])
+    const page = m[2]
+    const query: Record<string, string> = {
+      ...(to.query as Record<string, string>),
+    }
+    if (query.content) {
+      query.type = query.content
+      delete query.content
+    }
+    query.q = keyword
+    if (page && page !== '1') {
+      query.p = page
+    } else {
+      delete query.p
+    }
+    return navigateTo({ path: '/search', query }, { redirectCode: 302 })
+  }
+})
+```
+
+- [ ] **Step 2: 构建验证**
+
+Run: `pnpm build`
+Expected: `✨ Build complete!`，无错误。
+
+- [ ] **Step 3: 提交**
+
+```bash
+git add app/middleware/route-aliases.global.ts
+git commit -m "feat(search): redirect legacy /search/:keyword/:page URLs to query scheme"
+```
+
+---
+
+### Task 3: 更新内部链接到新方案
+
+把所有硬编码旧搜索路由的入口改为新 query 形态，并把两处 ArtTag 调用方的 `content` 键改为 `type`。
+
+**Files:**
+- Modify: `app/components/SearchBox.vue`
+- Modify: `app/components/ArtTag.vue`
+- Modify: `app/pages/index.vue`（随机背景 tag 点击）
+- Modify: `app/pages/novel/series/[id].vue`（ArtTag `content`→`type`）
+- Modify: `app/pages/novels/[id].vue`（ArtTag `content`→`type`）
+
+**Interfaces:**
+- Consumes: 新 `/search?q=&type=&...` 路由（Task 1）
+
+- [ ] **Step 1: `SearchBox.vue` —— 输入框初值与跳转改用 query**
+
+把第 15 行：
+
+```ts
+const keyword = ref((route.params.keyword as string) || '')
+```
+
+改为：
+
+```ts
+const keyword = ref((route.query.q as string) || '')
+```
+
+把第 25 行：
+
+```ts
+  router.push(`/search/${encodeURIComponent(keyword.value)}/1`)
+```
+
+改为：
+
+```ts
+  router.push({ path: '/search', query: { q: keyword.value } })
+```
+
+（保留 `id:数字` → `/artworks/:id` 快捷与空输入早返回。）
+
+- [ ] **Step 2: `ArtTag.vue` —— searchUrl 改用 query**
+
+把第 14-19 行的 `searchUrl`：
+
+```ts
+const searchUrl = computed(() => {
+  const base = `/search/${encodeURIComponent(props.tag)}/1`
+  if (!props.searchQuery || !Object.keys(props.searchQuery).length) return base
+  const qs = new URLSearchParams(props.searchQuery).toString()
+  return `${base}?${qs}`
+})
+```
+
+改为：
+
+```ts
+const searchUrl = computed(() => {
+  const params = new URLSearchParams({ q: props.tag, ...(props.searchQuery ?? {}) })
+  return `/search?${params.toString()}`
+})
+```
+
+- [ ] **Step 3: `index.vue` —— 随机背景 tag 点击改用 query**
+
+把第 62 行：
+
+```pug
+                @click='$router.push(`/search/${encodeURIComponent(tag)}/1`)',
+```
+
+改为：
+
+```pug
+                @click='$router.push({ path: "/search", query: { q: tag } })',
+```
+
+- [ ] **Step 4: 两处 ArtTag 调用方 `content`→`type`**
+
+`app/pages/novel/series/[id].vue` 第 32 行与 `app/pages/novels/[id].vue` 第 59 行，均把：
+
+```pug
+              :search-query='{ content: "novels", s_mode: "s_tag_only" }',
+```
+
+改为：
+
+```pug
+              :search-query='{ type: "novels", s_mode: "s_tag_only" }',
+```
+
+- [ ] **Step 5: 兜底排查无残留旧链接**
+
+Run:
+```bash
+grep -rn "/search/" app/ --include=*.vue --include=*.ts | grep -v "ajax/search" | grep -v "route-aliases.global.ts"
+```
+Expected: 无输出（除 middleware 注释/逻辑外，应无任何 `/search/:keyword` 形态的硬编码）。若有遗漏，按同样方式改为 `/search?q=...`。
+
+- [ ] **Step 6: 构建验证**
+
+Run: `pnpm build`
+Expected: `✨ Build complete!`，无错误。
+
+- [ ] **Step 7: 提交**
+
+```bash
+git add app/components/SearchBox.vue app/components/ArtTag.vue app/pages/index.vue "app/pages/novel/series/[id].vue" "app/pages/novels/[id].vue"
+git commit -m "refactor(search): update internal links to query-based search route"
+```
+
+---
+
+## 收尾验证（人工浏览器冒烟）
+
+- [ ] `pnpm dev`，依次确认：
+  - `/search` 落地页：显示搜索框 + 类型 tab + 筛选项，结果区为「输入关键词开始搜索」，Network 无搜索请求。
+  - 输入关键词回车 → `/search?q=...`，出结果。
+  - 切类型 tab / 改筛选（mode/order/s_mode/ai_type）→ URL query 变化、结果刷新、切类型时 `s_mode`/`lang` 重置、页码重置。
+  - 翻页 → URL 出现 `p=N`（第 1 页省略），结果正确。
+  - 旧 URL：`/search/foo` → 302 到 `/search?q=foo`；`/search/foo/2?content=novels&mode=r18` → `/search?q=foo&p=2&type=novels&mode=r18`。
+  - `id:123` 快捷 → `/artworks/123`。
+  - 作品页/小说页标签、首页随机背景标签跳转正确（小说页标签带 `type=novels&s_mode=s_tag_only`）。
+
+---
+
+## Self-Review 记录
+
+- **Spec 覆盖**：全 query 方案（Task 1）、`/search` 落地页（Task 1 landing 段）、旧 URL 302 兼容含 `content`→`type`（Task 2）、内部链接更新含两处 ArtTag 调用方（Task 3）、store/API 不动（全程未触及）—— 均有对应任务。
+- **类型/命名一致**：query 键 `q`/`type`/`p`/`mode`/`s_mode`/`order`/`ai_type`/`lang` 在 Task 1 页面、Task 2 重定向、Task 3 链接中一致；`setQuery`/`goPage`/`selectedType` 命名一致。
+- **Placeholder**：无 TBD/TODO；每个代码步骤均为完整代码或精确行替换。

--- a/docs/superpowers/specs/2026-06-23-search-routes-design.md
+++ b/docs/superpowers/specs/2026-06-23-search-routes-design.md
@@ -1,0 +1,94 @@
+# 搜索路由重构设计文档
+
+日期：2026-06-23
+
+## 背景与问题
+
+现有搜索路由 `/search/:keyword/:p`（`app/pages/search/[keyword]/[p].vue`，`name: 'search'`）存在两个问题：
+
+1. **没有 `/search` 根路由**：用户必须先输入关键词进入搜索页（默认综合模式），才能切换其他搜索方案。直接访问 `/search` 会 404。
+2. **URL 结构割裂**：keyword 与 page 在 path param，其余筛选项（`content`/`s_mode`/`order`/`mode`/`ai_type`/`lang`）在 query。同类参数被拆到两处，且需要 `middleware/route-aliases.global.ts` 把 `/search/:keyword` 补成 `/search/:keyword/1`，翻页还要在 path 里重拼 URL。
+
+## 目标
+
+- 改为**全 query 方案**：`/search?q=&type=&p=&mode=&s_mode=&order=&ai_type=&lang=`。
+- `/search`（无 `q`）成为**落地页**，可直接选搜索方案/筛选项再输入关键词。
+- 旧 URL **重定向兼容**。
+- **仅路由重构**，不新增搜索类型（不加用户搜索），不改 store / pixiv-client 方法签名、不改结果渲染语义。
+
+## 决策（已确认）
+
+- URL 方案：全 query `/search?q=...`。
+- 类型参数名：`content` → **`type`**（其余筛选键名不变）。
+- 旧 URL：**302 重定向**到新方案。
+- 落地空态：仅一句提示，不放热门标签/历史（YAGNI）。
+
+## 架构设计
+
+### 1. 路由与文件
+
+- `git mv app/pages/search/[keyword]/[p].vue app/pages/search.vue`（保留 git 历史），再删除空的 `app/pages/search/[keyword]/` 目录。
+- `app/pages/search.vue` 保留 `definePageMeta({ name: 'search' })`（`SiteHeader` 用 `$route.name !== 'search'` 隐藏自身搜索框的逻辑因此不受影响）。
+- 现有文件**约 85% 直接复用**：整个 `<template>`（类型 tab、refine 筛选栏、FnbSelect、error/loading/empty/结果区、分页）、全部选项数组、`<style>`、多数 computed、store 调用方式。
+
+### 2. query 参数模型
+
+| 参数 | 含义 | 默认（省略不写入 URL） |
+| --- | --- | --- |
+| `q` | 关键词 | 无（缺省即落地态） |
+| `type` | 搜索方案（artworks/illustrations/ugoira/manga/novels） | `artworks` |
+| `p` | 页码 | `1` |
+| `mode` | 分级 | `all` |
+| `s_mode` | 匹配方式 | `s_tag` |
+| `order` | 排序 | `date_d` |
+| `ai_type` | AI 过滤 | `''`（含 AI） |
+| `lang` | 小说语言（仅 novels） | `''` |
+
+沿用现有「默认值不写进 URL」的清洁策略。
+
+### 3. `search.vue` 改造点（约 15%）
+
+1. **数据源 path→query**：`makeSearch` 从 `route.query.q` 取关键词、`route.query.p` 取页码（替代 `route.params.keyword/p`）。
+2. **键名 `content`→`type`**：`selectedContent` 读 `route.query.type`；`defaults` 的键、`setQuery` 里 `'content' in updates` 的判断、类型 tab 点击 `setQuery({ type: opt.value })` 一并改名。
+3. **落地态**：无 `q` 时 `makeSearch` 早返回、不调用 API；结果区显示落地提示（如「输入关键词开始搜索」），与「搜索有结果为空（没有了…）」区分开。控制栏（搜索框 + 类型 tab + 筛选项）始终显示。
+4. **翻页简化**：`page` 由 `route.query.p` 驱动（computed）；`FnbPagination` 的 `@update:page` 改为 push 新 query（更新 `p`）。删除原先 `watch(page)` 里在 path 重拼 URL 的逻辑。
+5. **watcher 简化**：保留 `watch(() => route.query, makeSearch, { deep: true })`（现在 keyword/page 也在 query，一个 watch 即可覆盖）；删除 `onBeforeRouteUpdate`（不再有 params）。
+6. **标题**：`setTitle` 用 `route.query.q` / `route.query.p`；无 `q` 时标题为「搜索」。
+
+`setQuery` 现有实现（删默认值、切类型重置 `s_mode`/`lang`、`delete q.p`、`router.push({ query })`）本就是 query-based，键名改名后可直接用。
+
+### 4. 旧 URL 重定向兼容
+
+改写 `middleware/route-aliases.global.ts` 的 search 规则：匹配 `/search/:keyword` 与 `/search/:keyword/:page`，连同原有 query，302 重定向到 `/search?q=:keyword&p=:page&...`：
+
+- `keyword`：`decodeURIComponent` path 段后作为 `q`。
+- `page`：path 段缺省为 `1`；为 `1` 时按清洁策略可省略。
+- 原 query 中的 `content` 重命名为 `type`，其余键（`mode`/`s_mode`/`order`/`ai_type`/`lang`）原样保留。
+- 用 `navigateTo(..., { redirectCode: 302 })`。
+
+### 5. 内部链接更新
+
+所有硬编码旧路由的入口改为新 query 形态：
+
+- `SearchBox.vue`：`router.push({ path: '/search', query: { q: keyword.value } })`；保留 `id:数字` → `/artworks/:id` 快捷与空输入不动作。
+- `ArtTag.vue`：`searchUrl` 改为 `/search?q=<tag>` 并合并传入的 `searchQuery`。
+- `app/pages/index.vue`：随机背景 tag 的 `FnbTag` 点击改为 `/search?q=<tag>`。
+- 其余引用 `/search/.../1` 的位置一并改（实现时全局 grep `"/search/"` 兜底排查）。
+
+### 6. store / API
+
+`app/stores/search.ts` 与 `pixiv-client` 的搜索方法**不改**（仍按 keyword 调用）。仅页面读取数据源从 params 变为 query。
+
+## 测试与验证
+
+- 项目无测试框架。验证以 `pnpm build`（编译 + Pug 模板）为门禁，辅以浏览器冒烟：
+  - `/search` 落地页显示控制栏 + 提示、不发请求；
+  - 输入关键词跳转 `/search?q=...` 并出结果；切类型/筛选/翻页 URL 与结果正确；
+  - 旧 URL（`/search/:keyword`、`/search/:keyword/2?content=novels&mode=r18`）正确 302 到新方案；
+  - `id:123` 快捷仍生效；从作品页/首页 tag 跳转正确。
+
+## 不做（YAGNI）
+
+- 不新增用户搜索或任何新搜索类型。
+- 不改结果渲染、筛选项语义、store 与 API 方法签名。
+- 落地页不做热门标签/搜索历史。


### PR DESCRIPTION
## 概述

把搜索从 `/search/:keyword/:p`（path 参数）重构为全 query 方案 `/search?q=&type=&p=&...`，新增 `/search` 落地页，并对旧 URL 做 302 重定向兼容。顺带补了几个搜索相关的入口与交互。

## 主要改动

**核心路由重构**
- `git mv` 旧 `app/pages/search/[keyword]/[p].vue` → `app/pages/search.vue`，数据源从 path param 改为 query（`q`/`type`/`p`/`mode`/`s_mode`/`order`/`ai_type`/`lang`）。原 `content` 参数更名为 `type`。
- `/search`（无 `q`）成为落地页：显示搜索框 + 类型 tab + 筛选项，不发请求。
- 翻页改为 query `p` 驱动，删除原先在 path 重拼 URL 的逻辑；watcher 简化。
- 沿用「默认值不写入 URL」清洁策略。

**向后兼容**
- `route-aliases.global.ts` 把旧 `/search/:keyword(/:page)`（连同 query，`content`→`type`）302 重定向到新方案。

**内部链接更新**
- `SearchBox` / `ArtTag` / 首页随机背景 tag / 两处小说页 ArtTag（`content`→`type`）全部改用新 query 形态。

**新增入口与交互**
- 侧栏「导航」组新增「搜索」入口 → `/search`。
- 顶栏搜索框新增分类选择器（`useMediaQuery` 控制，≥768px 显示并生效、顶替放大镜图标；窄屏隐藏并默认综合）。选择器与输入框合并为一个新野兽派硬阴影药丸。
- 抽出共享 `app/utils/searchOptions.ts`（`contentOptions`），搜索页与顶栏共用，避免分类列表漂移。

## 设计与计划文档

- 设计：`docs/superpowers/specs/2026-06-23-search-routes-design.md`
- 计划：`docs/superpowers/plans/2026-06-23-search-routes.md`

## 测试

- 项目无单测框架。每个改动均通过 `pnpm build`（编译 + Pug 模板）门禁。
- 子代理流程对 3 个核心任务做了任务级 review + 整分支终审（结论 Ready to merge），顶栏选择器为后续手动迭代。
- 建议合并后浏览器冒烟：旧 URL 重定向、类型切换 `s_mode` 重置、`id:数字` 快捷、顶栏选择器响应式（≥768px / 窄屏）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 由 Sourcery 提供的总结

将搜索路由重构为基于查询参数的 `/search` 端点，引入新的搜索落地体验、更新内部链接，并在头部添加搜索类型选择器，同时保持对旧版 URL 的兼容性。

新功能：
- 引入基于查询参数的 `/search` 路由，从查询参数中读取搜索关键词、类型、分页和过滤条件，而不是使用路径片段。
- 新增 `/search` 的落地状态：在未提供关键词时展示搜索 UI 和使用说明，并在存在查询之前延迟发起网络请求。
- 在侧边导航中暴露一个搜索入口，直接指向新的 `/search` 路由。
- 在宽屏幕的头部搜索栏中添加搜索类型选择器，允许用户按内容类型限定搜索范围。
- 扩展 `SearchBox` 组件，使其接受可选的搜索类型和可隐藏的图标，从而可以在头部的胶囊布局中复用。

增强：
- 在共享的 `app/utils/searchOptions` 模块中统一搜索类型选项，由搜索页面和头部选择器共同使用，以保持类型列表的一致性。
- 简化搜索页面的分页逻辑，使其完全由 `p` 查询参数驱动，避免 URL 重建并降低监听逻辑的复杂度。
- 更新 `ArtTag`、首页随机背景标签和小说标签链接，使用新的基于查询参数的规则和重命名后的类型参数来生成搜索 URL。
- 调整头部搜索样式，在大屏视口上将范围选择器与搜索框合并为单一的胶囊式控件。

文档：
- 添加一份设计规范，记录新的基于查询参数的搜索路由、落地行为以及兼容性决策。
- 添加一份实现计划，详细说明迁移到新的 `/search` 路由及相关重构的分步过程。

日常维护：
- 将旧的 `/search/:keyword(/:page)` 中间件别名替换为重定向规则，把旧 URL 和内容查询参数映射到新的 `/search?q=&type=&p=` 查询模型。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor search routing to a query-based /search endpoint with a new landing experience, updated internal links, and a header search type selector while preserving compatibility with legacy URLs.

New Features:
- Introduce a query-based /search route that reads search keyword, type, pagination, and filters from query parameters instead of path segments.
- Add a /search landing state that shows the search UI and guidance when no keyword is provided and defers network requests until a query exists.
- Expose a search entry in the side navigation pointing directly to the new /search route.
- Add a search type selector to the header search bar on wide screens, allowing users to scope searches by content type.
- Extend the SearchBox component to accept an optional search type and hideable icon so it can be reused in the header pill layout.

Enhancements:
- Unify search type options in a shared app/utils/searchOptions module used by both the search page and header selector to keep type lists consistent.
- Simplify pagination on the search page to be driven purely by a p query parameter, avoiding URL reconstruction and reducing watcher complexity.
- Update ArtTag, home page random background tags, and novel tag links to generate search URLs with the new query-based scheme and renamed type parameter.
- Adjust header search styling to merge the scope selector and search box into a single pill-style control on larger viewports.

Documentation:
- Add a design spec documenting the new query-based search routing, landing behavior, and compatibility decisions.
- Add an implementation plan detailing the step-by-step migration to the new /search route and associated refactors.

Chores:
- Replace the legacy /search/:keyword(/:page) middleware alias with a redirect that maps old URLs and content query parameters onto the new /search?q=&type=&p= query model.

</details>